### PR TITLE
Implement Similarity Search Functions for SQLServer_VectorStore.

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -312,7 +312,7 @@ class SQLServer_VectorStore(VectorStore):
             with Session(self._bind) as session:
                 results = (
                     session.query(
-                        _embedding_store,
+                        self._embedding_store,
                         text(VECTOR_DISTANCE_QUERY).bindparams(
                             bindparam(
                                 DISTANCE_STRATEGY,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -176,6 +176,10 @@ class SQLServer_VectorStore(VectorStore):
         else:
             raise ValueError(f"{self._distance_strategy} is not supported.")
 
+    @distance_strategy.setter
+    def distance_strategy(self, value: DistanceStrategy):
+        self._distance_strategy = value
+
     @classmethod
     def from_texts(
         cls: Type[VST],

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -177,7 +177,7 @@ class SQLServer_VectorStore(VectorStore):
             raise ValueError(f"{self._distance_strategy} is not supported.")
 
     @distance_strategy.setter
-    def distance_strategy(self, value: DistanceStrategy):
+    def distance_strategy(self, value: DistanceStrategy) -> None:
         self._distance_strategy = value
 
     @classmethod

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -73,10 +73,10 @@ class SQLServer_VectorStore(VectorStore):
         self._create_table_if_not_exists()
 
     def _create_engine(self) -> Engine:
-        return create_engine(url=self.connection_string)  # , echo=True)
+        return create_engine(url=self.connection_string, echo=True)
 
     def _create_table_if_not_exists(self) -> None:
-        logging.info("Creating table %s", self.table_name)
+        logging.info("Creating table %s.", self.table_name)
         with Session(self._bind) as session:
             Base.metadata.create_all(session.get_bind())
 
@@ -232,12 +232,12 @@ class SQLServer_VectorStore(VectorStore):
     def _search_store(
         self, embedding: List[float], k: int, filter: Optional[dict] = None
     ) -> List[Any]:
-        # This variable will be passed as an argument to the filter function
+        # The filter variable will be passed as an argument to the filter function
         # filter_clause = self._create_filter_clause(filter)
         with Session(self._bind) as session:
             results = (
                 session.query(
-                    self.EmbeddingStore,
+                    _embedding_store,
                     text(
                         """VECTOR_DISTANCE(:distancestrategy, 
                         JSON_ARRAY_TO_VECTOR(:embedding), embeddings) AS distance"""
@@ -259,7 +259,7 @@ class SQLServer_VectorStore(VectorStore):
             )
         return results
 
-    def _create_filter_clause(self, filter: dict):
+    def _create_filter_clause(self, filter: dict) -> None:
         """TODO: parse filter and create a sql clause."""
 
     def _docs_from_result(self, results: Any) -> List[Document]:

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,13 +1,15 @@
-from typing import Any, Iterable, List, Optional, Type, Union
+from typing import Any, Iterable, List, Optional, Tuple, Type, Union
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VST, VectorStore
-from sqlalchemy import Column, Uuid, bindparam, create_engine, text
+from sqlalchemy import Column, Uuid, asc, bindparam, create_engine, text
 from sqlalchemy.dialects.mssql import JSON, NVARCHAR, VARBINARY, VARCHAR
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.orm import Session
+
+from langchain_community.vectorstores.utils import DistanceStrategy
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -36,7 +38,9 @@ class SQLServer_VectorStore(VectorStore):
         *,
         connection: Optional[Connection] = None,
         connection_string: str,
+        distance_strategy: DistanceStrategy = DistanceStrategy.COSINE,
         embedding_function: Embeddings,
+        embedding_length: int = 8000,
         table_name: str,
     ) -> None:
         """Initialize the SQL Server vector store.
@@ -44,14 +48,23 @@ class SQLServer_VectorStore(VectorStore):
         Args:
             connection: Optional SQLServer connection.
             connection_string: SQLServer connection string.
+            distance_strategy: The distance strategy to use for comparing embeddings.
+                Default value is COSINE. Available options are:
+                - COSINE
+                - DOT
+                - EUCLIDEAN
             embedding_function: Any embedding function implementing
                 `langchain.embeddings.base.Embeddings` interface.
+            embedding_length: The length of the vectors to be stored in the table
+                Defaults to 8000 if not specified.
             table_name: The name of the table to use for storing embeddings.
 
         """
 
         self.connection_string = connection_string
+        self._distance_strategy = distance_strategy
         self.embedding_function = embedding_function
+        self._embedding_length = embedding_length
         self.table_name = table_name
         self._bind: Union[Connection, Engine] = (
             connection if connection else self._create_engine()
@@ -60,7 +73,7 @@ class SQLServer_VectorStore(VectorStore):
         self._create_table_if_not_exists()
 
     def _create_engine(self) -> Engine:
-        return create_engine(url=self.connection_string, echo=True)
+        return create_engine(url=self.connection_string)  # , echo=True)
 
     def _create_table_if_not_exists(self) -> None:
         logging.info("Creating table %s", self.table_name)
@@ -80,7 +93,7 @@ class SQLServer_VectorStore(VectorStore):
             custom_id = Column(VARCHAR, nullable=True)  # column for user defined ids.
             query_metadata = Column(JSON, nullable=True)
             query = Column(NVARCHAR, nullable=False)  # defaults to NVARCHAR(MAX)
-            embeddings = Column(VARBINARY, nullable=False)
+            embeddings = Column(VARBINARY(self._embedding_length), nullable=False)
 
         _embedding_store = EmbeddingStore
         return _embedding_store
@@ -88,6 +101,18 @@ class SQLServer_VectorStore(VectorStore):
     @property
     def embeddings(self) -> Embeddings:
         return self.embedding_function
+
+    @property
+    def distance_strategy(self) -> str:
+        # Value of distance strategy passed in should be one of the supported values.
+        if self._distance_strategy == DistanceStrategy.EUCLIDEAN_DISTANCE:
+            return "euclidean"
+        elif self._distance_strategy == DistanceStrategy.COSINE:
+            return "cosine"
+        elif self._distance_strategy == DistanceStrategy.DOT_PRODUCT:
+            return "dot"
+        else:
+            raise ValueError(f"{self._distance_strategy} is not supported.")
 
     @classmethod
     def from_texts(
@@ -103,8 +128,69 @@ class SQLServer_VectorStore(VectorStore):
     def similarity_search(
         self, query: str, k: int = 4, **kwargs: Any
     ) -> List[Document]:
-        # placeholder
-        return []
+        """Return docs most similar to given query.
+
+        Args:
+            query: Text to look up the most similar embedding to.
+            k: Number of Documents to return. Defaults to 4.
+
+        Returns:
+            List of Documents most similar to the query.
+        """
+        embedded_query = self.embedding_function.embed_query(query)
+        return self.similarity_search_by_vector(embedded_query, k, **kwargs)
+
+    def similarity_search_by_vector(
+        self, embedding: List[float], k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        """Return docs most similar to the embedding vector.
+
+        Args:
+            embedding: Embedding to look up documents similar to.
+            k: Number of Documents to return. Defaults to 4.
+
+        Returns:
+            List of Documents most similar to the query vector.
+        """
+        similar_docs_with_scores = self.similarity_search_by_vector_with_score(
+            embedding, k, **kwargs
+        )
+        return self._docs_from_result(similar_docs_with_scores)
+
+    def similarity_search_with_score(
+        self, query: str, k: int = 4, **kwargs: Any
+    ) -> List[Tuple[Document, float]]:
+        """Run similarity search with distance and
+            return docs most similar to the embedding vector.
+
+        Args:
+            query: Text to look up the most similar embedding to.
+            k: Number of Documents to return. Defaults to 4.
+
+        Returns:
+            List of Documents most similar to the query vector
+            and an accompanying score for each vector.
+        """
+        embedded_query = self.embedding_function.embed_query(query)
+        return self.similarity_search_by_vector_with_score(embedded_query, k, **kwargs)
+
+    def similarity_search_by_vector_with_score(
+        self, embedding: List[float], k: int = 4, **kwargs: Any
+    ) -> List[Tuple[Document, float]]:
+        """Run similarity search with distance, given an embedding
+            and return docs most similar to the embedding vector.
+
+        Args:
+            embedding: Embedding to look up documents similar to.
+            k: Number of Documents to return. Defaults to 4.
+
+        Returns:
+            List of Documents most similar to the query vector
+            and an accompanying score for each vector.
+        """
+        similar_docs = self._search_store(embedding, k, **kwargs)
+        docs = self._docs_and_scores_from_result(similar_docs)
+        return docs
 
     def add_texts(
         self,
@@ -143,6 +229,59 @@ class SQLServer_VectorStore(VectorStore):
         except ProgrammingError as e:
             logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
 
+    def _search_store(
+        self, embedding: List[float], k: int, filter: Optional[dict] = None
+    ) -> List[Any]:
+        # This variable will be passed as an argument to the filter function
+        # filter_clause = self._create_filter_clause(filter)
+        with Session(self._bind) as session:
+            results = (
+                session.query(
+                    self.EmbeddingStore,
+                    text(
+                        """VECTOR_DISTANCE(:distancestrategy, 
+                        JSON_ARRAY_TO_VECTOR(:embedding), embeddings) AS distance"""
+                    ).bindparams(
+                        bindparam(
+                            "distancestrategy",
+                            self.distance_strategy,
+                            literal_execute=True,
+                        ),
+                        bindparam(
+                            "embedding", json.dumps(embedding), literal_execute=True
+                        ),
+                    ),
+                )
+                .filter()
+                .order_by(asc(text("distance")))
+                .limit(k)
+                .all()
+            )
+        return results
+
+    def _create_filter_clause(self, filter: dict):
+        """TODO: parse filter and create a sql clause."""
+
+    def _docs_from_result(self, results: Any) -> List[Document]:
+        """Formats the input into a result of type List[Document]."""
+        docs = [result[0] for result in results]
+        return docs
+
+    def _docs_and_scores_from_result(
+        self, results: Any
+    ) -> List[Tuple[Document, float]]:
+        """Formats the input into a result of type Tuple[Document, float]."""
+        docs = [
+            (
+                Document(
+                    page_content=result[0].query, metadata=result[0].query_metadata
+                ),
+                result[1],
+            )
+            for result in results
+        ]
+        return docs
+
     def _insert_embeddings(
         self,
         texts: Iterable[str],
@@ -167,10 +306,10 @@ class SQLServer_VectorStore(VectorStore):
         if metadatas is None:
             metadatas = [{} for _ in texts]
 
-        if ids is None:
-            ids = [metadata.pop("id", uuid.uuid4()) for metadata in metadatas]
-
         try:
+            if ids is None:
+                ids = [metadata.pop("id", uuid.uuid4()) for metadata in metadatas]
+
             with Session(self._bind) as session:
                 documents = []
                 for idx, query in enumerate(texts):
@@ -208,12 +347,9 @@ class SQLServer_VectorStore(VectorStore):
                 session.bulk_save_objects(documents)
                 session.commit()
         except DBAPIError as e:
-            logging.error(f"Add text failed:\n {e.__cause__}.")
+            logging.error(f"Add text failed:\n {e.__cause__}")
+            raise
+        except AttributeError:
+            logging.error("Metadata must be a list of dictionaries.")
             raise
         return ids
-
-    def drop(self) -> None:
-        logging.info("Dropping vector store: %s.", self.table_name)
-        with Session(bind=self._bind) as session:
-            # Drop all the tables associated with the session bind.
-            Base.metadata.drop_all(session.get_bind())

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -28,6 +28,11 @@ import logging
 import uuid
 
 
+_embedding_store: Any = None # One vector store used for the entirety of the program.
+
+Base = declarative_base()  # type: Any
+
+
 class DistanceStrategy(str, Enum):
     """Enumerator of the distance strategies for calculating distances
     between vectors.
@@ -37,10 +42,6 @@ class DistanceStrategy(str, Enum):
     COSINE = "cosine"
     DOT = "dot"
 
-
-Base = declarative_base()  # type: Any
-
-_embedding_store: Any = None
 
 # String Constants
 #

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -211,3 +211,9 @@ class SQLServer_VectorStore(VectorStore):
             logging.error(f"Add text failed:\n {e.__cause__}.")
             raise
         return ids
+
+    def drop(self) -> None:
+        logging.info("Dropping vector store: %s.", self.table_name)
+        with Session(bind=self._bind) as session:
+            # Drop all the tables associated with the session bind.
+            Base.metadata.drop_all(session.get_bind())

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -27,7 +27,6 @@ import json
 import logging
 import uuid
 
-
 _embedding_store: Any = None # One vector store used for the entirety of the program.
 
 Base = declarative_base()  # type: Any

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -495,7 +495,7 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     assert "_CS" in collation_query_result.collation_name
 
     store.add_texts(texts)
-    store._distance_strategy = DistanceStrategy.DOT
+    store.distance_strategy = DistanceStrategy.DOT
 
     # Call to similarity_search function should not error out.
     number_of_docs_to_return = 2

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -480,6 +480,6 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     store._distance_strategy = DistanceStrategy.DOT
 
     # Call to similarity_search function should not error out.
-    number_of_docs_to_return = 3
+    number_of_docs_to_return = 2
     result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
     assert result is not None and len(result) == number_of_docs_to_return

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -480,6 +480,6 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     store._distance_strategy = DistanceStrategy.DOT
 
     # Call to similarity_search function should not error out.
-    number_of_docs_to_return = 2
+    number_of_docs_to_return = 3
     result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
     assert result is not None and len(result) == number_of_docs_to_return

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -473,7 +473,10 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
 
     conn = create_engine(connection_string_to_master).connect()
     conn.rollback()
-    conn.connection.dbapi_connection.autocommit = True
+
+    if conn.connection.dbapi_connection is not None:
+        conn.connection.dbapi_connection.autocommit = True
+
     conn.execute(text(_CREATE_COLLATION_DB_QUERY))
     conn.execute(text(f"use {_COLLATION_DB_NAME}"))
 

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -118,7 +118,7 @@ def test_sqlserver_add_texts(
     texts: List[str],
     metadatas: List[dict],
 ) -> None:
-    """Test that add text returns equivalent number of ids of input texts."""
+    """Test that `add_texts` returns equivalent number of ids of input texts."""
     result = store.add_texts(texts, metadatas)
     assert len(result) == len(texts)
 

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -471,14 +471,14 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     a call to similarity search does not fail."""
     connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
 
-    connection = create_engine(connection_string_to_master).connect()
-    connection.rollback()
-    connection._dbapi_connection.dbapi_connection.autocommit = True
-    connection.execute(text(_CREATE_COLLATION_DB_QUERY))
-    connection.execute(text(f"use {_COLLATION_DB_NAME}"))
+    conn = create_engine(connection_string_to_master).connect()
+    conn.rollback()
+    conn.connection.dbapi_connection.autocommit = True
+    conn.execute(text(_CREATE_COLLATION_DB_QUERY))
+    conn.execute(text(f"use {_COLLATION_DB_NAME}"))
 
     store = SQLServer_VectorStore(
-        connection=connection,
+        connection=conn,
         connection_string=connection_string_to_master,
         # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
         embedding_length=EMBEDDING_LENGTH,
@@ -486,7 +486,7 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
         table_name=_TABLE_NAME,
     )
     collation_query_result = (
-        connection.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
+        conn.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
     )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
 
     assert (
@@ -504,6 +504,6 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     assert result is not None and len(result) == number_of_docs_to_return
 
     # Drop DB with case sensitive collation for test.
-    connection.execute(text("use master"))
-    connection.execute(text(_DROP_COLLATION_DB_QUERY))
-    connection.close()
+    conn.execute(text("use master"))
+    conn.execute(text(_DROP_COLLATION_DB_QUERY))
+    conn.close()

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -419,7 +419,7 @@ def test_that_only_same_size_embeddings_can_be_added_to_store(
     store: SQLServer_VectorStore,
     texts: List[str],
 ) -> None:
-    """Tests that when embedding_length is provided, the vector store can
+    """Tests that the vector store can
     take only vectors of same dimensions."""
     # Create a SQLServer_VectorStore without `embedding_length` defined.
     store.add_texts(texts)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -461,8 +461,8 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     store: SQLServer_VectorStore,
     texts: List[str],
 ) -> None:
-    """Test that when distance strategy with mixed case is set on a
-    case sensitive DB, a call to similarity search does not fail."""
+    """Test that when distance strategy is set on a case sensitive DB,
+    a call to similarity search does not fail."""
 
     connection = create_engine(_CONNECTION_STRING).connect()
     collation_query_result = (
@@ -477,7 +477,7 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     assert "_CS" in collation_query_result.collation_name
 
     store.add_texts(texts)
-    store._distance_strategy = DistanceStrategy.DOT.capitalize()  # Returns 'Dot'
+    store._distance_strategy = DistanceStrategy.DOT
 
     # Call to similarity_search function should not error out.
     number_of_docs_to_return = 2

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -8,7 +8,10 @@ from langchain_core.documents import Document
 from sqlalchemy import create_engine, text
 
 from langchain_community.embeddings import FakeEmbeddings
-from langchain_community.vectorstores.sqlserver import SQLServer_VectorStore
+from langchain_community.vectorstores.sqlserver import (
+    DistanceStrategy,
+    SQLServer_VectorStore,
+)
 
 _CONNECTION_STRING = str(os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING"))
 _SCHEMA = "lc_test"
@@ -474,7 +477,7 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     assert "_CS" in collation_query_result.collation_name
 
     store.add_texts(texts)
-    store._distance_strategy = "Dot"
+    store._distance_strategy = DistanceStrategy.DOT.capitalize()  # Returns 'Dot'
 
     # Call to similarity_search function should not error out.
     number_of_docs_to_return = 2

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -199,7 +199,7 @@ def test_that_add_text_fails_if_text_embedding_length_is_not_equal_to_embedding_
     store: SQLServer_VectorStore,
     texts: List[str],
 ) -> None:
-    """Test that a call to add_text will raise an exception if the embedding_length of
+    """Test that a call to add_texts will raise an exception if the embedding_length of
     the embedding function in use is not the same as the embedding_length used in
     creating the vector store."""
     store.add_texts(texts)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -175,13 +175,12 @@ def test_that_a_document_entry_without_metadata_will_be_added_to_vectorstore(
     assert len(result) == len(docs)
 
 
-def test_that_drop_deletes_vector_store(
-    store: SQLServer_VectorStore,
-    texts: List[str],
-) -> None:
-    """Test that when drop is called, vector store is deleted
-    and a call to add_text raises an exception.
-    """
+def test_that_drop_deletes_vector_store(store) -> None:
     store.drop()
-    with pytest.raises(DBAPIError):
-        store.add_texts(texts)
+
+    texts = ["rabbit", "cherry", "hamster", "cat", "elderberry"]
+    result = store.add_texts(texts)
+
+    assert (
+        result is None
+    ), "There were entries to a vector store that should be dropped."

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -159,6 +159,18 @@ def test_that_a_document_entry_without_metadata_will_be_added_to_vectorstore(
     assert len(result) == len(documents)
 
 
+def test_that_drop_deletes_vector_store(
+    store: SQLServer_VectorStore,
+    texts: List[str],
+) -> None:
+    """Test that when drop is called, vector store is deleted
+    and a call to add_text raises an exception.
+    """
+    store.drop()
+    with pytest.raises(DBAPIError):
+        store.add_texts(texts)
+
+
 def test_that_similarity_search_returns_expected_no_of_documents(
     store: SQLServer_VectorStore,
     texts: List[str],

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -159,18 +159,6 @@ def test_that_a_document_entry_without_metadata_will_be_added_to_vectorstore(
     assert len(result) == len(documents)
 
 
-def test_that_drop_deletes_vector_store(
-    store: SQLServer_VectorStore,
-    texts: List[str],
-) -> None:
-    """Test that when drop is called, vector store is deleted
-    and a call to add_text raises an exception.
-    """
-    store.drop()
-    with pytest.raises(DBAPIError):
-        store.add_texts(texts)
-
-
 def test_that_similarity_search_returns_expected_no_of_documents(
     store: SQLServer_VectorStore,
     texts: List[str],

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -6,7 +6,6 @@ from typing import List
 import pytest
 from langchain_core.documents import Document
 from sqlalchemy.exc import DBAPIError
-from typing import List
 
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores.sqlserver import SQLServer_VectorStore
@@ -64,7 +63,7 @@ def store() -> SQLServer_VectorStore:
 
 
 @pytest.fixture
-def docs():
+def docs() -> List[Document]:
     """Definition of doc variable used in the tests."""
     docs = [
         Document(
@@ -87,16 +86,23 @@ def docs():
             metadata={"color": "blue", "type": "fruit", "length": 10},
         ),
     ]
-    yield docs  # provide this data to the test
+    return docs  # provide this data to the test
 
 
-def test_sqlserver_add_texts(store, texts, metadatas) -> None:
+def test_sqlserver_add_texts(
+    store: SQLServer_VectorStore,
+    texts: List[str],
+    metadatas: List[dict],
+) -> None:
     """Test that add text returns equivalent number of ids of input texts."""
     result = store.add_texts(texts, metadatas)
     assert len(result) == len(texts)
 
 
-def test_sqlserver_add_texts_when_no_metadata_is_provided(store, texts) -> None:
+def test_sqlserver_add_texts_when_no_metadata_is_provided(
+    store: SQLServer_VectorStore,
+    texts: List[str],
+) -> None:
     """Test that when user calls the add_texts function without providing metadata,
     the embedded text still get added to the vector store."""
     result = store.add_texts(texts)
@@ -104,7 +110,9 @@ def test_sqlserver_add_texts_when_no_metadata_is_provided(store, texts) -> None:
 
 
 def test_sqlserver_add_texts_when_text_length_and_metadata_length_vary(
-    store, texts, metadatas
+    store: SQLServer_VectorStore,
+    texts: List[str],
+    metadatas: List[dict],
 ) -> None:
     """Test that all texts provided are added into the vector store
     even when metadata is not available for all the texts."""
@@ -116,7 +124,9 @@ def test_sqlserver_add_texts_when_text_length_and_metadata_length_vary(
 
 
 def test_sqlserver_add_texts_when_list_of_given_id_is_less_than_list_of_texts(
-    store, texts, metadatas
+    store: SQLServer_VectorStore,
+    texts: List[str],
+    metadatas: List[dict],
 ) -> None:
     """Test that when length of given id is less than length of texts,
     random ids are created."""
@@ -128,15 +138,19 @@ def test_sqlserver_add_texts_when_list_of_given_id_is_less_than_list_of_texts(
     assert len(result) == len(texts)
 
 
-def test_add_document_with_sqlserver(store, docs) -> None:
-    """Test that when add_document function is used, it integerates well
+def test_add_document_with_sqlserver(
+    store: SQLServer_VectorStore,
+    docs: List[Document],
+) -> None:
+    """Test that when add_document function is used, it integrates well
     with the add_text function in SQLServer Vector Store."""
     result = store.add_documents(docs)
     assert len(result) == len(docs)
 
 
 def test_that_a_document_entry_without_metadata_will_be_added_to_vectorstore(
-    store: SQLServer_VectorStore, docs
+    store: SQLServer_VectorStore,
+    docs: List[Document],
 ) -> None:
     """Test that you can add a document that has no metadata into the vectorstore."""
     documents = docs[:-1]
@@ -145,7 +159,10 @@ def test_that_a_document_entry_without_metadata_will_be_added_to_vectorstore(
     assert len(result) == len(documents)
 
 
-def test_that_drop_deletes_vector_store(store, texts) -> None:
+def test_that_drop_deletes_vector_store(
+    store: SQLServer_VectorStore,
+    texts: List[str],
+) -> None:
     """Test that when drop is called, vector store is deleted
     and a call to add_text raises an exception.
     """
@@ -154,7 +171,10 @@ def test_that_drop_deletes_vector_store(store, texts) -> None:
         store.add_texts(texts)
 
 
-def test_that_similarity_search_returns_expected_no_of_documents(store, texts) -> None:
+def test_that_similarity_search_returns_expected_no_of_documents(
+    store: SQLServer_VectorStore,
+    texts: List[str],
+) -> None:
     """Test that the amount of documents returned when similarity search
     is called is the same as the number of documents requested."""
     store.add_texts(texts)
@@ -163,7 +183,8 @@ def test_that_similarity_search_returns_expected_no_of_documents(store, texts) -
 
 
 def test_that_similarity_search_returns_results_with_scores_sorted_in_ascending_order(
-    store, texts
+    store: SQLServer_VectorStore,
+    texts: List[str],
 ) -> None:
     """Assert that the list returned by a similarity search
     is sorted in an ascending order. The implication is that

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -190,13 +190,13 @@ def test_that_add_text_fails_if_text_embedding_length_is_not_equal_to_embedding_
     texts: List[str],
 ) -> None:
     """Test that a call to add_text will raise an exception if the embedding_length of
-    the embedding function in use is not the same as the embedding_length used in 
+    the embedding function in use is not the same as the embedding_length used in
     creating the vector store."""
     store.add_texts(texts)
 
     # Assign a new embedding function with a different length to the store.
     #
-    store.embedding_function = FakeEmbeddings(size=384) # a different size is used.
+    store.embedding_function = FakeEmbeddings(size=384)  # a different size is used.
 
     with pytest.raises(Exception):
         # add_texts should fail and raise an exception since embedding length of
@@ -247,6 +247,7 @@ def test_that_similarity_search_returns_results_with_scores_sorted_in_ascending_
     """
     store.add_texts(texts)
     number_of_docs_to_return = 4
-    doc_with_score = store.similarity_search_with_score("Good review", 
-                                                        k=number_of_docs_to_return)
+    doc_with_score = store.similarity_search_with_score(
+        "Good review", k=number_of_docs_to_return
+    )
     assert doc_with_score == sorted(doc_with_score, key=lambda x: x[1])


### PR DESCRIPTION
## Why make this change?
This PR contains implementation of several similarity search functions and accompanying tests for the functions. Changes made in this PR are made towards implementing these functions.

## What is this change?
This PR contains the following implementations / changes:

**New Parameters in _init_ function**
```
azvs = SQLServer_VectorStore(
    connection_string=_CONNECTION_STRING,
    distance_strategy=DistanceStrategy.COSINE,
    embedding_length = 1536,
    embedding_function=CohereEmbeddings(
        cohere_api_key="COHERE_API_KEY",
        model="embed-english-light-v3.0",
    ),
    table_name="langchain_vector_store_test",
)
```
- constructor takes in additional parameters
    - `distance_strategy` - for calculating vector distances. This property can be updated outside of the constructor also.
    `azvs._distance_strategy = DistanceStrategy.DOT` or `azvs.distance_strategy = "dot"`
    - `embedding_length` - This value is used to create a `check` constraint on the `embeddings` column. This ensures that only embeddings of the same length can be added to the vector store and allows us to successfully perform a similarity search.
- rename columns of the vector store.
- addition of a `CHECK` constraint to the `embeddings` column. This constraint ensures that only embeddings of the same length can be added to the vector store.
- different similarity search functions for SQLServerVectorStore. These include:
    - similarity_search -> Takes in a string as input and returns a list of `Document` after having performed a similarity search based on the given distance strategy.
    - similarity_search_by_vector -> Takes in a vector as the input and returns a list of `Document` after performing a similarity search using the given distance strategy.
    - similarity_search_with_score -> This differs from the `similarity_search` function because of its return type. This function will return a list of semantically similar documents along with the vector distance score.
    - similarity_search_by_vector_with_score -> This differs from the `similarity_search_by_vector` function because of its return type. This function will return a list of semantically similar documents along with the vector distance score.

**Helper Functions**
- _docs_and_scores_from_result -> This function formats the result of similarity_search from SQLServer into a tuple containing `Document` and `float`.
- _docs_from_result -> This function formats the result of similarity_search from SQLServer to return `Document`.
- _search_store -> This contains the call to SQLServer with the TSQL query for similarity search. It is the function underneath the different similarity_search functions provided above. A template of the result here is seen below:

`[(<langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._get_embedding_store.<locals>.EmbeddingStore object at 0x000002B73C6F8610>, 0.5401342754176245), (<langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._get_embedding_store.<locals>.EmbeddingStore object at 0x000002B73C6F8850>, 0.6400343794736375)]`

## How was this tested?
- Additional tests have been added to take into account the similarity_search functions. We've also modified the test implementation by creating fixtures that can be re-used throughout the test phases.
- We ensure that every vector store created during the test run is dropped after the test case completes. This is to ensure that test cases do not have dependencies on each other.

![image](https://github.com/user-attachments/assets/6c022483-af85-4934-99e1-3db57cb67de6)

NB: These tests will be moved in a later PR to the integration test folder and proper unit tests will be created also.