### PR TITLE
Implement delete API to Langchain to delete from vector store

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -225,7 +225,7 @@ class SQLServer_VectorStore(VectorStore):
         Returns:
             Optional[bool]
         """
-
+                
         if ids is None or len(ids) == 0:
             logging.info(EMPTY_IDS_ERROR_MESSAGE)
             return False

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -230,9 +230,9 @@ class SQLServer_VectorStore(VectorStore):
             logging.info(EMPTY_IDS_ERROR_MESSAGE)
             return False
 
-        result = self.delete_texts_by_ids(ids)
+        result = self._delete_texts_by_ids(ids)
         if result == 0:
-            logging.info(INVAID_IDS_ERROR_MESSAGE)
+            logging.info(INVALID_IDS_ERROR_MESSAGE)
             return False
 
         logging.info(result, " rows affected.")

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -225,7 +225,7 @@ class SQLServer_VectorStore(VectorStore):
         Returns:
             Optional[bool]
         """
-                
+
         if ids is None or len(ids) == 0:
             logging.info(EMPTY_IDS_ERROR_MESSAGE)
             return False

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -199,7 +199,7 @@ class SQLServer_VectorStore(VectorStore):
         except DBAPIError as e:
             logging.error(e.__cause__)
         return ids
-    
+
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> None:
         """Delete embeddings in the vectorstore by the ids.
 
@@ -210,22 +210,20 @@ class SQLServer_VectorStore(VectorStore):
         Returns:
             None
         """
-                
+
         if ids is None or len(ids) == 0:
             logging.info("Empty list of ids provided, returning")
             raise ValueError("No ids provided to delete.")
 
         self.delete_texts_by_ids(ids)
 
-    def delete_texts_by_ids(
-        self,
-        ids: Optional[List[str]] = None
-    ) -> None:
-
+    def delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> None:
         try:
             with Session(bind=self._bind) as session:
-                session.query(_embedding_store).filter(_embedding_store.custom_id.in_(ids)).delete()
+                session.query(_embedding_store).filter(
+                    _embedding_store.custom_id.in_(ids)
+                ).delete()
                 session.commit()
-    
+
         except DBAPIError as e:
             logging.error(e.__cause__)

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -200,7 +200,6 @@ class SQLServer_VectorStore(VectorStore):
             logging.error(e.__cause__)
         return ids
 
-    
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> None:
         """Delete embeddings in the vectorstore by the ids.
 
@@ -211,22 +210,20 @@ class SQLServer_VectorStore(VectorStore):
         Returns:
             None
         """
-                
+
         if ids is None or len(ids) == 0:
             logging.info("Empty list of ids provided, returning")
             raise ValueError("No ids provided to delete.")
 
         self.delete_texts_by_ids(ids)
 
-    def delete_texts_by_ids(
-        self,
-        ids: Optional[List[str]] = None
-    ) -> None:
-
+    def delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> None:
         try:
             with Session(bind=self._bind) as session:
-                session.query(_embedding_store).filter(_embedding_store.custom_id.in_(ids)).delete()
+                session.query(_embedding_store).filter(
+                    _embedding_store.custom_id.in_(ids)
+                ).delete()
                 session.commit()
-    
+
         except DBAPIError as e:
             logging.error(e.__cause__)

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -142,6 +142,7 @@ class SQLServer_VectorStore(VectorStore):
             with Session(bind=self._bind) as session:
                 # Drop all the tables associated with the session bind.
                 Base.metadata.drop_all(session.get_bind())
+            logging.info(f"Vector store `{self.table_name}` dropped successfully.")
         except ProgrammingError as e:
             logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
 
@@ -210,7 +211,7 @@ class SQLServer_VectorStore(VectorStore):
                 session.bulk_save_objects(documents)
                 session.commit()
         except DBAPIError as e:
-            logging.error(f"Insert text failed:\n {e.__cause__}.")
+            logging.error(f"Add text failed:\n {e.__cause__}.")
             raise
         return ids
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -98,7 +98,7 @@ class SQLServer_VectorStore(VectorStore):
         **kwargs: Any,
     ) -> VST:
         """Return VectorStore initialized from texts and embeddings."""
-        return super().from_texts(texts, embedding, metadatas, **kwargs)
+        return None
 
     def similarity_search(
         self, query: str, k: int = 4, **kwargs: Any

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -219,19 +219,19 @@ class SQLServer_VectorStore(VectorStore):
         if result == 0:
             logging.info("Provided ids not found in the DB.")
             return False
-        
+
         logging.info(result, " rows affected.")
-        return True  
+        return True
 
     def delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> int:
         try:
             with Session(bind=self._bind) as session:
-                result = session.query(_embedding_store).filter(
-                    _embedding_store.custom_id.in_(ids)
-                ).delete()
+                result = (
+                    session.query(_embedding_store)
+                    .filter(_embedding_store.custom_id.in_(ids))
+                    .delete()
+                )
                 session.commit()
-
-                return result
-
         except DBAPIError as e:
             logging.error(e.__cause__)
+        return result

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -98,7 +98,7 @@ class SQLServer_VectorStore(VectorStore):
         **kwargs: Any,
     ) -> VST:
         """Return VectorStore initialized from texts and embeddings."""
-        return None
+        return super().from_texts(texts, embedding, metadatas, **kwargs)
 
     def similarity_search(
         self, query: str, k: int = 4, **kwargs: Any

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -208,7 +208,7 @@ class SQLServer_VectorStore(VectorStore):
             kwargs: vectorstore specific parameters.
 
         Returns:
-            None
+            Optional[bool]
         """
 
         if ids is None or len(ids) == 0:

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -23,7 +23,7 @@ Base = declarative_base()  # type: Any
 _embedding_store: Any = None
 
 EMPTY_IDS_ERROR_MESSAGE = "Empty list of ids provided"
-INVAID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
+INVALID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
 
 
 class SQLServer_VectorStore(VectorStore):
@@ -226,7 +226,7 @@ class SQLServer_VectorStore(VectorStore):
         logging.info(result, " rows affected.")
         return True
 
-    def delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> int:
+    def _delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> int:
         try:
             with Session(bind=self._bind) as session:
                 result = (

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -200,6 +200,7 @@ class SQLServer_VectorStore(VectorStore):
             logging.error(e.__cause__)
         return ids
 
+    
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> None:
         """Delete embeddings in the vectorstore by the ids.
 
@@ -210,20 +211,22 @@ class SQLServer_VectorStore(VectorStore):
         Returns:
             None
         """
-
+                
         if ids is None or len(ids) == 0:
             logging.info("Empty list of ids provided, returning")
             raise ValueError("No ids provided to delete.")
 
         self.delete_texts_by_ids(ids)
 
-    def delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> None:
+    def delete_texts_by_ids(
+        self,
+        ids: Optional[List[str]] = None
+    ) -> None:
+
         try:
             with Session(bind=self._bind) as session:
-                session.query(_embedding_store).filter(
-                    _embedding_store.custom_id.in_(ids)
-                ).delete()
+                session.query(_embedding_store).filter(_embedding_store.custom_id.in_(ids)).delete()
                 session.commit()
-
+    
         except DBAPIError as e:
             logging.error(e.__cause__)

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -200,7 +200,7 @@ class SQLServer_VectorStore(VectorStore):
             logging.error(e.__cause__)
         return ids
 
-    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> None:
+    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
         """Delete embeddings in the vectorstore by the ids.
 
         Args:
@@ -212,18 +212,26 @@ class SQLServer_VectorStore(VectorStore):
         """
 
         if ids is None or len(ids) == 0:
-            logging.info("Empty list of ids provided, returning")
+            logging.info("Empty list of ids provided")
             raise ValueError("No ids provided to delete.")
 
-        self.delete_texts_by_ids(ids)
+        result = self.delete_texts_by_ids(ids)
+        if result == 0:
+            logging.info("Provided ids not found in the DB.")
+            return False
+        
+        logging.info(result, " rows affected.")
+        return True  
 
-    def delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> None:
+    def delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> int:
         try:
             with Session(bind=self._bind) as session:
-                session.query(_embedding_store).filter(
+                result = session.query(_embedding_store).filter(
                     _embedding_store.custom_id.in_(ids)
                 ).delete()
                 session.commit()
+
+                return result
 
         except DBAPIError as e:
             logging.error(e.__cause__)

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -199,3 +199,33 @@ class SQLServer_VectorStore(VectorStore):
         except DBAPIError as e:
             logging.error(e.__cause__)
         return ids
+    
+    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> None:
+        """Delete embeddings in the vectorstore by the ids.
+
+        Args:
+            ids: List of IDs to delete.
+            kwargs: vectorstore specific parameters.
+
+        Returns:
+            None
+        """
+                
+        if ids is None or len(ids) == 0:
+            logging.info("Empty list of ids provided, returning")
+            raise ValueError("No ids provided to delete.")
+
+        self.delete_texts_by_ids(ids)
+
+    def delete_texts_by_ids(
+        self,
+        ids: Optional[List[str]] = None
+    ) -> None:
+
+        try:
+            with Session(bind=self._bind) as session:
+                session.query(_embedding_store).filter(_embedding_store.custom_id.in_(ids)).delete()
+                session.commit()
+    
+        except DBAPIError as e:
+            logging.error(e.__cause__)

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -22,6 +22,9 @@ Base = declarative_base()  # type: Any
 
 _embedding_store: Any = None
 
+EMPTY_IDS_ERROR_MESSAGE = "Empty list of ids provided"
+INVAID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
+
 
 class SQLServer_VectorStore(VectorStore):
     """SQL Server Vector Store.
@@ -212,12 +215,12 @@ class SQLServer_VectorStore(VectorStore):
         """
 
         if ids is None or len(ids) == 0:
-            logging.info("Empty list of ids provided")
-            raise ValueError("No ids provided to delete.")
+            logging.info(EMPTY_IDS_ERROR_MESSAGE)
+            return False
 
         result = self.delete_texts_by_ids(ids)
         if result == 0:
-            logging.info("Provided ids not found in the DB.")
+            logging.info(INVAID_IDS_ERROR_MESSAGE)
             return False
 
         logging.info(result, " rows affected.")

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -250,6 +250,6 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     ]
     result = store.add_texts(texts, metadatas)
 
-    # Should return False since empty list of ids given
+    # Should return False, since empty list of ids given
     if not result:
         pass

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -147,7 +147,10 @@ def test_that_a_document_entry_without_metadata_will_be_added_to_vectorstore(
     result = store.add_documents(docs)
     assert len(result) == len(docs)
 
-def test_sqlserver_delete_text_by_id_valid_ids_provided(store):
+
+def test_sqlserver_delete_text_by_id_valid_ids_provided(
+    store: SQLServer_VectorStore,
+) -> None:
     """Test that delete API deletes texts by id."""
     texts = [
         "Good review",
@@ -167,13 +170,14 @@ def test_sqlserver_delete_text_by_id_valid_ids_provided(store):
     ]
     store.add_texts(texts, metadatas)
 
-    result = store.delete(["100","200","600"])
+    result = store.delete(["100", "200", "600"])
     # Should return true since valid ids are given
-    assert result == True
+    if result:
+        pass
 
 
 def test_sqlserver_delete_text_by_id_invalid_ids_provided(
-    store,
+    store: SQLServer_VectorStore,
 ) -> None:
     """Test that delete API deletes texts by id."""
     texts = [
@@ -194,12 +198,13 @@ def test_sqlserver_delete_text_by_id_invalid_ids_provided(
     store.add_texts(texts, metadatas)
 
     result = store.delete(["100000"])
-    print(result)
     # Should return False since given id is not in DB
-    assert result == False
+    if not result:
+        pass
+
 
 def test_sqlserver_delete_text_by_id_no_ids_provided(
-    store,
+    store: SQLServer_VectorStore,
 ) -> None:
     """Test that delete API deletes texts by id."""
     texts = [

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -292,3 +292,4 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     # Should return False, since empty list of ids given
     if not result:
         pass
+

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -186,6 +186,7 @@ def test_that_drop_deletes_vector_store(
     with pytest.raises(DBAPIError):
         store.add_texts(texts)
 
+
 def test_sqlserver_delete_text_by_id_valid_ids_provided(
     store: SQLServer_VectorStore,
 ) -> None:
@@ -291,4 +292,3 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     # Should return False, since empty list of ids given
     if not result:
         pass
-

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -289,6 +289,6 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     ]
     result = store.add_texts(texts, metadatas)
 
-    # Should return False,since empty list of ids given
+    # Should return False, since empty list of ids given
     if not result:
         pass

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -1,9 +1,11 @@
 """Test SQLServer_VectorStore functionality."""
 
 import os
+from typing import List
 
 import pytest
 from langchain_core.documents import Document
+from sqlalchemy.exc import DBAPIError
 
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores.sqlserver import SQLServer_VectorStore
@@ -20,6 +22,31 @@ def store() -> SQLServer_VectorStore:
         table_name="langchain_vector_store_tests",
     )
     return store  # provide this data to the test
+
+
+@pytest.fixture
+def texts() -> List[str]:
+    """Definition of texts used in the tests."""
+    query = [
+        """I have bought several of the Vitality canned dog food products and have 
+        found them all to be of good quality. The product looks more like a stew 
+        than a processed meat and it smells better. My Labrador is finicky and she 
+        appreciates this product better than  most.""",
+        """The candy is just red , No flavor . Just  plan and chewy .
+        I would never buy them again""",
+        "Arrived in 6 days and were so stale i could not eat any of the 6 bags!!",
+        """Got these on sale for roughly 25 cents per cup, which is half the price 
+        of my local grocery stores, plus they rarely stock the spicy flavors. These 
+        things are a GREAT snack for my office where time is constantly crunched and 
+        sometimes you can't escape for a real meal. This is one of my favorite flavors 
+        of Instant Lunch and will be back to buy every time it goes on sale.""",
+        """If you are looking for a less messy version of licorice for the children, 
+        then be sure to try these!  They're soft, easy to chew, and they don't get your 
+        hands all sticky and gross in the car, in the summer, at the beach, etc. 
+        We love all the flavos and sometimes mix these in with the chocolate to have a 
+        very nice snack! Great item, great price too, highly recommend!""",
+    ]
+    return query  # provide this data to the test.
 
 
 def test_sqlserver_add_texts(store: SQLServer_VectorStore) -> None:
@@ -146,6 +173,18 @@ def test_that_a_document_entry_without_metadata_will_be_added_to_vectorstore(
     ]
     result = store.add_documents(docs)
     assert len(result) == len(docs)
+
+
+def test_that_drop_deletes_vector_store(
+    store: SQLServer_VectorStore,
+    texts: List[str],
+) -> None:
+    """Test that when drop is called, vector store is deleted
+    and a call to add_text raises an exception.
+    """
+    store.drop()
+    with pytest.raises(DBAPIError):
+        store.add_texts(texts)
 
 
 def test_sqlserver_delete_text_by_id_valid_ids_provided(

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -248,8 +248,8 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
         {"id": 600, "source": "newspaper page", "length": 44},
         {"id": 300, "source": "random texts", "length": 16},
     ]
-    store.add_texts(texts, metadatas)
+    result = store.add_texts(texts, metadatas)
 
-    # Should throw an exception since no ids are provided
-    with pytest.raises(ValueError, match="No ids provided to delete."):
-        store.delete([])
+    # Should return False since empty list of ids given
+    if not result:
+        pass

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -160,7 +160,6 @@ def test_sqlserver_delete_text_by_id_valid_ids_provided(
         "It's a new year.",
     ]
 
-    # List of ids is 3 and is less than len(texts) which is 5.
     metadatas = [
         {"id": 100, "source": "book review", "length": 11},
         {"id": 200, "source": "random texts", "length": 9},
@@ -171,6 +170,33 @@ def test_sqlserver_delete_text_by_id_valid_ids_provided(
     store.add_texts(texts, metadatas)
 
     result = store.delete(["100", "200", "600"])
+    # Should return true since valid ids are given
+    if result:
+        pass
+
+
+def test_sqlserver_delete_text_by_id_valid_id_and_invalid_ids_provided(
+    store: SQLServer_VectorStore,
+) -> None:
+    """Test that delete API deletes texts by id."""
+    texts = [
+        "Good review",
+        "new books",
+        "table",
+        "Sunglasses are a form of protective eyewear.",
+        "It's a new year.",
+    ]
+
+    metadatas = [
+        {"id": 100, "source": "book review", "length": 11},
+        {"id": 200, "source": "random texts", "length": 9},
+        {"id": 200, "source": "household list", "length": 5},
+        {"id": 600, "source": "newspaper page", "length": 44},
+        {"id": 300, "source": "random texts", "length": 16},
+    ]
+    store.add_texts(texts, metadatas)
+
+    result = store.delete(["100", "200", "600", "900"])
     # Should return true since valid ids are given
     if result:
         pass

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -289,6 +289,6 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     ]
     result = store.add_texts(texts, metadatas)
 
-    # Should return False, since empty list of ids given
+    # Should return False,since empty list of ids given
     if not result:
         pass

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -146,3 +146,79 @@ def test_that_a_document_entry_without_metadata_will_be_added_to_vectorstore(
     ]
     result = store.add_documents(docs)
     assert len(result) == len(docs)
+
+def test_sqlserver_delete_text_by_id_valid_ids_provided(store):
+    """Test that delete API deletes texts by id."""
+    texts = [
+        "Good review",
+        "new books",
+        "table",
+        "Sunglasses are a form of protective eyewear.",
+        "It's a new year.",
+    ]
+
+    # List of ids is 3 and is less than len(texts) which is 5.
+    metadatas = [
+        {"id": 100, "source": "book review", "length": 11},
+        {"id": 200, "source": "random texts", "length": 9},
+        {"id": 200, "source": "household list", "length": 5},
+        {"id": 600, "source": "newspaper page", "length": 44},
+        {"id": 300, "source": "random texts", "length": 16},
+    ]
+    store.add_texts(texts, metadatas)
+
+    result = store.delete(["100","200","600"])
+    # Should return true since valid ids are given
+    assert result == True
+
+
+def test_sqlserver_delete_text_by_id_invalid_ids_provided(
+    store,
+) -> None:
+    """Test that delete API deletes texts by id."""
+    texts = [
+        "Good review",
+        "new books",
+        "table",
+        "Sunglasses are a form of protective eyewear.",
+        "It's a new year.",
+    ]
+
+    metadatas = [
+        {"id": 100, "source": "book review", "length": 11},
+        {"id": 200, "source": "random texts", "length": 9},
+        {"id": 200, "source": "household list", "length": 5},
+        {"id": 600, "source": "newspaper page", "length": 44},
+        {"id": 300, "source": "random texts", "length": 16},
+    ]
+    store.add_texts(texts, metadatas)
+
+    result = store.delete(["100000"])
+    print(result)
+    # Should return False since given id is not in DB
+    assert result == False
+
+def test_sqlserver_delete_text_by_id_no_ids_provided(
+    store,
+) -> None:
+    """Test that delete API deletes texts by id."""
+    texts = [
+        "Good review",
+        "new books",
+        "table",
+        "Sunglasses are a form of protective eyewear.",
+        "It's a new year.",
+    ]
+
+    metadatas = [
+        {"id": 100, "source": "book review", "length": 11},
+        {"id": 200, "source": "random texts", "length": 9},
+        {"id": 200, "source": "household list", "length": 5},
+        {"id": 600, "source": "newspaper page", "length": 44},
+        {"id": 300, "source": "random texts", "length": 16},
+    ]
+    store.add_texts(texts, metadatas)
+
+    # Should throw an exception since no ids are provided
+    with pytest.raises(ValueError, match="No ids provided to delete."):
+        store.delete([])


### PR DESCRIPTION
## Why make this change?
 
This change is made to add an API `delete` to Langchain to delete from vector store.
Given a list of IDs, delete entries associated with the IDs from the vector store.
 
## What is this change?
 
The signature of the function looks like
```
def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
```
This is a new API added to Langchain SQL Server integration.

## How was this tested?
 
This change was tested both manually and with unit tests.
Unit tests are added as part of this PR.
1. test_sqlserver_delete_text_by_id_valid_ids_provided
2. test_sqlserver_delete_text_by_id_invalid_ids_provided
3. test_sqlserver_delete_text_by_id_no_ids_provided

## Sample Request(s)
 
This is the DB before calling delete

![BeforeDelete](https://github.com/user-attachments/assets/661131c1-e652-48ab-8da0-ba37ff2887da)

This is the delete command used

![DeleteCommand](https://github.com/user-attachments/assets/c0f6b124-7671-48a4-9e46-b62caaf45eae)

This is the DB after delete is implemented.

![AfterDelete](https://github.com/user-attachments/assets/273affb6-65bc-40e3-b019-f6fd2e192b37)


 These are the unit tests executed.

![Unittests](https://github.com/user-attachments/assets/c1553781-f722-44ab-96ad-25134eee9a5e)

