### PR TITLE
Drop VectorStore

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -139,6 +139,7 @@ class SQLServer_VectorStore(VectorStore):
             with Session(bind=self._bind) as session:
                 # Drop all the tables associated with the session bind.
                 Base.metadata.drop_all(session.get_bind())
+            logging.info(f"Vector store `{self.table_name}` dropped successfully.")
         except ProgrammingError as e:
             logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
 
@@ -207,6 +208,6 @@ class SQLServer_VectorStore(VectorStore):
                 session.bulk_save_objects(documents)
                 session.commit()
         except DBAPIError as e:
-            logging.error(f"Insert text failed:\n {e.__cause__}.")
+            logging.error(f"Add text failed:\n {e.__cause__}.")
             raise
         return ids

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -6,7 +6,7 @@ from langchain_core.vectorstores import VST, VectorStore
 from sqlalchemy import Column, Uuid, bindparam, create_engine, text
 from sqlalchemy.dialects.mssql import JSON, NVARCHAR, VARBINARY, VARCHAR
 from sqlalchemy.engine import Connection, Engine
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.orm import Session
 
 try:
@@ -132,6 +132,16 @@ class SQLServer_VectorStore(VectorStore):
         # Insert the embedded texts in the vector store table.
         return self._insert_embeddings(texts, embedded_texts, metadatas, ids)
 
+    def drop(self) -> None:
+        """Drops every table created during initialization of vector store."""
+        logging.info(f"Dropping vector store: {self.table_name}")
+        try:
+            with Session(bind=self._bind) as session:
+                # Drop all the tables associated with the session bind.
+                Base.metadata.drop_all(session.get_bind())
+        except ProgrammingError as e:
+            logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
+
     def _insert_embeddings(
         self,
         texts: Iterable[str],
@@ -197,5 +207,6 @@ class SQLServer_VectorStore(VectorStore):
                 session.bulk_save_objects(documents)
                 session.commit()
         except DBAPIError as e:
-            logging.error(e.__cause__)
+            logging.error(f"Insert text failed:\n {e.__cause__}.")
+            raise
         return ids


### PR DESCRIPTION
## Why make this change?

This PR contains drop vector store implementation. The vector store created when `SQLServer_VectorStore` is initialized can be dropped using this function. Users are provided with this functionality to be able to drop a vector store table when needed.

## What is this change?

- `drop` implementation - When called, all tables created during initialization are deleted. If a programming error occurs, this is logged.
- Update private function `_insert_embeddings` to raise a `DBApiError` if it encounters an error while inserting to table. Any error here is logged as well.
- Test for `drop` function - 
    - Added a pytest fixture for `texts`. This value can be re-used across the tests. Existing tests will need to be modified to use this in another PR.
    - `test_that_drop_deletes_vector_store` checks that the `drop` function does delete a vector store by checking that a DBAPI exception is raised when you attempt to `add_text` to a vector store after calling the `drop` function.

## How was this tested?
Details of the test run are shown below:

![image](https://github.com/user-attachments/assets/7ca2b9e5-a2f6-4d4d-9b89-9b3f6e848c1c)



