### PR TITLE
Anushakolan/sqlserver vectorstore

### DIFF
--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -110,7 +110,7 @@ def test_sqlserver_add_texts_when_list_of_given_id_is_less_than_list_of_texts(
 
     # List of ids is 3 and is less than len(texts) which is 5.
     metadatas = [
-        {"id": 1, "soure": "book review", "length": 11},
+        {"id": 1, "source": "book review", "length": 11},
         {"id": 2, "source": "random texts", "length": 9},
         {"source": "household list", "length": 5},
         {"id": 6, "source": "newspaper page", "length": 44},

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -289,7 +289,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     ]
     result = store.add_texts(texts, metadatas)
 
-    result = store.delete([])
+    result = store.delete(None)
     # Should return False, since empty list of ids given
     if not result:
         pass

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -289,6 +289,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     ]
     result = store.add_texts(texts, metadatas)
 
+    result = store.delete([])
     # Should return False, since empty list of ids given
     if not result:
         pass


### PR DESCRIPTION
## Why make this change?
The PR contains a fix to a unit test `test_sqlserver_delete_text_by_id_no_ids_provided`

## What is this change?
This PR contains a call to the delete API in a unit test

## How was this tested?
<img width="1484" alt="image" src="https://github.com/user-attachments/assets/9c094293-361e-49fa-90f9-76582b303ad0">


NB: These tests will be moved in a later PR to the integration test folder and proper unit tests will be created also.