### PR TITLE
Multi-Vector store creation.

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -178,7 +178,7 @@ class SQLServer_VectorStore(VectorStore):
             metadatas = [{} for _ in texts]
 
         if ids is None:
-            # Copy data from metadatas so data is not updated in-place.
+            # Get IDs from metadata if available.
             ids = [metadata.get("id", uuid.uuid4()) for metadata in metadatas]
 
         try:

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -73,13 +73,11 @@ class SQLServer_VectorStore(VectorStore):
                 self._embedding_store.__table__.create(
                     session.get_bind(), checkfirst=True
                 )
-
         except ProgrammingError as e:
             logging.error(f"Create table {self.table_name} failed.")
             raise Exception(e.__cause__) from None
 
     def _get_embedding_store(self, name: str, schema: Optional[str]) -> Any:
-
         DynamicBase = declarative_base(class_registry=dict())  # type: Any
         class EmbeddingStore(DynamicBase):
             """This is the base model for SQL vector store."""
@@ -150,7 +148,6 @@ class SQLServer_VectorStore(VectorStore):
                 self._embedding_store.__table__.drop(session.get_bind())
 
             logging.info(f"Vector store `{self.table_name}` dropped successfully.")
-
         except ProgrammingError as e:
             logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -79,6 +79,7 @@ class SQLServer_VectorStore(VectorStore):
 
     def _get_embedding_store(self, name: str, schema: Optional[str]) -> Any:
         DynamicBase = declarative_base(class_registry=dict())  # type: Any
+
         class EmbeddingStore(DynamicBase):
             """This is the base model for SQL vector store."""
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -176,7 +176,7 @@ class SQLServer_VectorStore(VectorStore):
             metadatas = [{} for _ in texts]
 
         if ids is None:
-            # Copy data from metadatas so data is not updated in-place
+            # Copy data from metadatas so data is not updated in-place.
             metadata_to_format = copy.deepcopy(metadatas)
             ids = [metadata.pop("id", uuid.uuid4()) for metadata in metadata_to_format]
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -79,7 +79,7 @@ class SQLServer_VectorStore(VectorStore):
             raise Exception(e.__cause__) from None
 
     def _get_embedding_store(self, name: str, schema: Optional[str]) -> Any:
-         
+
         DynamicBase = declarative_base(class_registry=dict())  # type: Any
         class EmbeddingStore(DynamicBase):
             """This is the base model for SQL vector store."""
@@ -179,7 +179,6 @@ class SQLServer_VectorStore(VectorStore):
             metadatas = [{} for _ in texts]
 
         if ids is None:
-
             # Copy data from metadatas so data is not updated in-place
             metadata_to_format = copy.deepcopy(metadatas)
             ids = [metadata.pop("id", uuid.uuid4()) for metadata in metadata_to_format]
@@ -197,8 +196,8 @@ class SQLServer_VectorStore(VectorStore):
                         id = ids[-1]
                     embedding = embeddings[idx]
                     metadata = (
-                        metadata_to_format[idx] 
-                        if idx < len(metadata_to_format) 
+                        metadata_to_format[idx]
+                        if idx < len(metadata_to_format)
                         else None
                     )
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -46,7 +46,7 @@ class SQLServer_VectorStore(VectorStore):
             connection: Optional SQLServer connection.
             connection_string: SQLServer connection string.
             db_schema: The schema in which the vector store will be created.
-                This schema must exist and user must have permissions to the schema.
+                This schema must exist and the user must have permissions to the schema.
             embedding_function: Any embedding function implementing
                 `langchain.embeddings.base.Embeddings` interface.
             table_name: The name of the table to use for storing embeddings.

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -349,4 +349,4 @@ def test_that_schema_input_is_used() -> None:
 
     # Confirm table in that schema exists.
     result = connection.execute(text(sys_table_query))
-    assert result.fetchone() is not None
+    assert result.fetchone() is not None, f"Table {schema}.{table_name} does not exist."

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -295,3 +295,22 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     # Should return False, since empty list of ids given
     if not result:
         pass
+
+
+def test_that_multiple_vector_stores_can_be_created(
+    store: SQLServer_VectorStore,
+) -> None:
+    """Tests that when multiple SQLServer_VectorStore objects are
+    created, the first created vector store is not reused, but
+    multiple vector stores are created."""
+
+    # Create another vector store with a different table name.
+    new_store = SQLServer_VectorStore(
+        connection_string=_CONNECTION_STRING,
+        embedding_function=FakeEmbeddings(size=1536),
+        table_name="langchain_vector_store_tests_2",
+    )
+
+    # Check that the name of the table being created for the embeddingstore
+    # is what is expected.
+    assert new_store._embedding_store.__table__.name == "langchain_vector_store_tests_2"

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -1,7 +1,7 @@
 """Test SQLServer_VectorStore functionality."""
 
 import os
-from typing import List
+from typing import Generator, List
 
 import pytest
 from langchain_core.documents import Document
@@ -14,14 +14,17 @@ _CONNECTION_STRING = str(os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING")
 
 
 @pytest.fixture
-def store() -> SQLServer_VectorStore:
+def store() -> Generator[SQLServer_VectorStore, None, None]:
     """Setup resources that are needed for the duration of the test."""
     store = SQLServer_VectorStore(
         connection_string=_CONNECTION_STRING,
         embedding_function=FakeEmbeddings(size=1536),
         table_name="langchain_vector_store_tests",
     )
-    return store  # provide this data to the test
+    yield store  # provide this data to the test
+
+    # Drop store after it's done being used in the test case.
+    store.drop()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why make this change?
In the current implementation for `SQLServer_VectorStore`, we observe a behavior where creating multiple `SQLServer_VectorStore` objects and passing different table names to those objects does not create multiple vector stores but instead creates and reuses the first vector store. This change will ensure that multiple vector stores can be created in a session.

Ability to specify `DB schema` is also introduced in this change.

## What is this change?
- Add `db_schema` to `init` function: When the user provides this, the vector store is created within the provided schema. In a case where no schema is provided, it defaults to the default schema on the DB (in most cases, `dbo`).
- We no longer keep a global `embedding_store`. Instead, we create an EmbeddingStore object using `DynamicBase` from `sqlalchemy` which ensures we don't have clashes while creating this objects from different `SQLServer_VectorStore` invokings. This also ensures that we are able to create differently named vector stores.
- Creating and dropping of the vector store are done by calling the `create` and `drop` function of the table object associated with the `EmbeddingStore` object.

**_Init function - Sample Invocation_**
```
store = SQLServer_VectorStore(
    connection_string=_CONNECTION_STRING,
    db_schema="lct",  #sample schema name.
    embedding_function=CohereEmbeddings(
        cohere_api_key="COHERE_API_KEY",
        model="embed-english-light-v3.0",
    ),
    table_name="langchain_store_connection_test",
)
```

## Tests
- We now ensure that the vector store created in a test case run is dropped once the test case run is completed.
- Additional test added to verify that when a multiple `SQLServer_VectorStore` objects are created with different table names, the base model used in creating table actually uses/creates the appropriate table.

![image](https://github.com/user-attachments/assets/05bbd4aa-3f76-4421-a0dc-188928e27987)
