### PR TITLE
Hybrid search implementation

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -30,7 +30,6 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
-import copy
 import json
 import logging
 import uuid

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -119,7 +119,6 @@ class SQLServer_VectorStore(VectorStore):
         connection_string: str,
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
-        db_schema: Optional[str] = None,
         embedding_function: Embeddings,
         embedding_length: int,
         table_name: str,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
@@ -7,10 +7,15 @@ from langchain_core.vectorstores import VST, VectorStore
 from sqlalchemy import (
     CheckConstraint,
     Column,
+    ColumnElement,
+    Numeric,
+    SQLColumnExpression,
     Uuid,
     asc,
     bindparam,
+    cast,
     create_engine,
+    func,
     label,
     text,
 )
@@ -18,6 +23,7 @@ from sqlalchemy.dialects.mssql import JSON, NVARCHAR, VARBINARY, VARCHAR
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import operators
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -27,6 +33,45 @@ except ImportError:
 import json
 import logging
 import uuid
+
+import sqlalchemy
+
+_embedding_store: Any = None  # One vector store used for the entirety of the program.
+
+Base = declarative_base()  # type: Any
+
+COMPARISONS_TO_NATIVE: Dict[str, Callable[[ColumnElement, object], ColumnElement]] = {
+    "$eq": operators.eq,
+    "$ne": operators.ne,
+}
+
+NUMERIC_OPERATORS: Dict[str, Callable[[ColumnElement, object], ColumnElement]] = {
+    "$lt": operators.lt,
+    "$lte": operators.le,
+    "$gt": operators.gt,
+    "$gte": operators.ge,
+}
+
+SPECIAL_CASED_OPERATORS = {
+    "$in",
+    "$nin",
+    "$between",
+}
+
+TEXT_OPERATORS = {
+    "$like",
+    "$ilike",
+}
+
+LOGICAL_OPERATORS = {"$and", "$or"}
+
+SUPPORTED_OPERATORS = (
+    set(COMPARISONS_TO_NATIVE)
+    .union(NUMERIC_OPERATORS)
+    .union(SPECIAL_CASED_OPERATORS)
+    .union(TEXT_OPERATORS)
+    .union(LOGICAL_OPERATORS)
+)
 
 
 class DistanceStrategy(str, Enum):
@@ -310,6 +355,11 @@ class SQLServer_VectorStore(VectorStore):
     ) -> List[Any]:
         try:
             with Session(self._bind) as session:
+                filter_by = []
+                filter_clauses = self._create_filter_clause(filter)
+                if filter_clauses is not None:
+                    filter_by.append(filter_clauses)
+
                 results = (
                     session.query(
                         self._embedding_store,
@@ -329,7 +379,7 @@ class SQLServer_VectorStore(VectorStore):
                             ),
                         ),
                     )
-                    .filter()
+                    .filter(*filter_by)
                     .order_by(asc(text(DISTANCE)))
                     .limit(k)
                     .all()
@@ -340,12 +390,230 @@ class SQLServer_VectorStore(VectorStore):
 
         return results
 
-    def _create_filter_clause(self, filter: dict) -> None:
-        """TODO: parse filter and create a sql clause."""
+    def _create_filter_clause(self, filters: Any) -> Any:
+        """Convert LangChain IR filter representation to matching SQLAlchemy clauses.
 
-    def _docs_from_result(
-        self, results: List[Tuple[Document, float]]
-    ) -> List[Document]:
+        At the top level,we still don't know if we're working with a field
+        or an operator for the keys. After we've determined that we can
+        call the appropriate logic to handle filter creation.
+
+        Args:
+            filters: Dictionary of filters to apply to the query.
+
+        Returns:
+            SQLAlchemy clause to apply to the query.
+        """
+        if filters is not None:
+            # Here we want a list of filters instead of dict
+            if not isinstance(filters, dict):
+                raise ValueError(
+                    f"Expected a dict, but got {type(filters)} for value: {filter}"
+                )
+            if len(filters) == 1:
+                # The only operators allowed at the top level are $AND and $OR
+                # First check if an operator or a field
+                key, value = list(filters.items())[0]
+                if key.startswith("$"):
+                    # Then it's an operator
+                    if key.lower() not in ["$and", "$or"]:
+                        raise ValueError(
+                            f"Invalid filter condition. Expected $and or $or "
+                            f"but got: {key}"
+                        )
+                else:
+                    # Then it's a field
+                    return self._handle_field_filter(key, filters[key])
+
+                # Here we handle the $and and $or operators
+                if not isinstance(value, list):
+                    raise ValueError(
+                        f"Expected a list, but got {type(value)} for value: {value}"
+                    )
+                if key.lower() == "$and":
+                    and_ = [self._create_filter_clause(el) for el in value]
+                    if len(and_) > 1:
+                        return sqlalchemy.and_(*and_)
+                    elif len(and_) == 1:
+                        return and_[0]
+                    else:
+                        raise ValueError(
+                            "Invalid filter condition. Expected a dictionary "
+                            "but got an empty dictionary"
+                        )
+                elif key.lower() == "$or":
+                    or_ = [self._create_filter_clause(el) for el in value]
+                    if len(or_) > 1:
+                        return sqlalchemy.or_(*or_)
+                    elif len(or_) == 1:
+                        return or_[0]
+                    else:
+                        raise ValueError(
+                            "Invalid filter condition. Expected a dictionary "
+                            "but got an empty dictionary"
+                        )
+
+                else:
+                    raise ValueError(
+                        f"Invalid filter condition. Expected $and or $or "
+                        f"but got: {key}"
+                    )
+
+            elif len(filters) > 1:
+                # Then all keys have to be fields (they cannot be operators)
+                for key in filters.keys():
+                    if key.startswith("$"):
+                        raise ValueError(
+                            f"Invalid filter condition. Expected a field but got: {key}"
+                        )
+                # These should all be fields and combined using an $and operator
+                and_ = [self._handle_field_filter(k, v) for k, v in filters.items()]
+                if len(and_) > 1:
+                    return sqlalchemy.and_(*and_)
+                elif len(and_) == 1:
+                    return and_[0]
+                else:
+                    raise ValueError(
+                        "Invalid filter condition. Expected a dictionary "
+                        "but got an empty dictionary"
+                    )
+            else:
+                raise ValueError("Got an empty dictionary for filters.")
+        else:
+            logging.info("No filters are passed, returning")
+            return None
+
+    def _handle_field_filter(
+        self,
+        field: str,
+        value: Any,
+    ) -> SQLColumnExpression:
+        """Create a filter for a specific field.
+
+        Args:
+            field: name of field
+            value: value to filter
+                If provided as is then this will be an equality filter
+                If provided as a dictionary then this will be a filter, the key
+                will be the operator and the value will be the value to filter by
+
+        Returns:
+            sqlalchemy expression
+        """
+
+        if not isinstance(field, str):
+            raise ValueError(
+                f"field should be a string but got: {type(field)} with value: {field}"
+            )
+
+        if field.startswith("$"):
+            raise ValueError(
+                f"Invalid filter condition. Expected a field but got an operator: "
+                f"{field}"
+            )
+
+        # Allow [a-zA-Z0-9_], disallow $ for now until we support escape characters
+        if not field.isidentifier():
+            raise ValueError(
+                f"Invalid field name: {field}. Expected a valid identifier."
+            )
+
+        if isinstance(value, dict):
+            # This is a filter specification that only 1 filter will be for a given
+            # field, if multiple filters they are mentioned separately and used with
+            # an AND on the top if nothing is specified
+            if len(value) != 1:
+                raise ValueError(
+                    "Invalid filter condition. Expected a value which "
+                    "is a dictionary with a single key that corresponds to an operator "
+                    f"but got a dictionary with {len(value)} keys. The first few "
+                    f"keys are: {list(value.keys())[:3]}"
+                )
+            operator, filter_value = list(value.items())[0]
+            # Verify that operator is an operator
+            if operator not in SUPPORTED_OPERATORS:
+                raise ValueError(
+                    f"Invalid operator: {operator}. "
+                    f"Expected one of {SUPPORTED_OPERATORS}"
+                )
+        else:  # Then we assume an equality operator
+            operator = "$eq"
+            filter_value = value
+
+        if operator in COMPARISONS_TO_NATIVE:
+            operation = COMPARISONS_TO_NATIVE[operator]
+            native_result = func.JSON_VALUE(
+                self._embedding_store.content_metadata, f"$.{field}"
+            )
+            native_operation_result = operation(native_result, str(filter_value))
+            return native_operation_result
+
+        elif operator in NUMERIC_OPERATORS:
+            operation = NUMERIC_OPERATORS[str(operator)]
+            numeric_result = func.JSON_VALUE(
+                self._embedding_store.content_metadata, f"$.{field}"
+            )
+            numeric_operation_result = operation(numeric_result, filter_value)
+
+            if not isinstance(filter_value, str):
+                numeric_operation_result = operation(
+                    cast(numeric_result, Numeric(10, 2)), filter_value
+                )
+
+            return numeric_operation_result
+
+        elif operator == "$between":
+            # Use AND with two comparisons
+            low, high = filter_value
+
+            # Assuming lower_bound_value is a ColumnElement
+            lower_bound_value = func.JSON_VALUE(
+                self._embedding_store.content_metadata, f"$.{field}"
+            )
+
+            greater_operation = NUMERIC_OPERATORS["$gte"]
+            lesser_operation = NUMERIC_OPERATORS["$lte"]
+
+            lower_bound = greater_operation(lower_bound_value, low)
+            upper_bound = lesser_operation(lower_bound_value, high)
+
+            # Conditionally cast if filter_value is not a string
+            if not isinstance(filter_value, str):
+                lower_bound = greater_operation(
+                    cast(lower_bound_value, Numeric(10, 2)), low
+                )
+                upper_bound = lesser_operation(
+                    cast(lower_bound_value, Numeric(10, 2)), high
+                )
+
+            return sqlalchemy.and_(lower_bound, upper_bound)
+
+        elif operator in {"$in", "$nin", "$like", "$ilike"}:
+            # We'll do force coercion to text
+            if operator in {"$in", "$nin"}:
+                for val in filter_value:
+                    if not isinstance(val, (str, int, float)):
+                        raise NotImplementedError(
+                            f"Unsupported type: {type(val)} for value: {val}"
+                        )
+
+            queried_field = func.JSON_VALUE(
+                self._embedding_store.content_metadata, f"$.{field}"
+            )
+
+            if operator in {"$in"}:
+                return queried_field.in_([str(val) for val in filter_value])
+            elif operator in {"$nin"}:
+                return queried_field.nin_([str(val) for val in filter_value])
+            elif operator in {"$like"}:
+                return queried_field.like(str(filter_value))
+            elif operator in {"$ilike"}:
+                return queried_field.ilike(filter_value)
+            else:
+                raise NotImplementedError()
+        else:
+            raise NotImplementedError()
+
+    def _docs_from_result(self, results: Any) -> List[Document]:
         """Formats the input into a result of type List[Document]."""
         docs = [doc for doc, _ in results if doc is not None]
         return docs

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -30,6 +30,7 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
+import copy
 import json
 import logging
 import uuid
@@ -119,6 +120,7 @@ class SQLServer_VectorStore(VectorStore):
         connection_string: str,
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
+        db_schema: Optional[str] = None,
         embedding_function: Embeddings,
         embedding_length: int,
         table_name: str,
@@ -178,6 +180,7 @@ class SQLServer_VectorStore(VectorStore):
             """This is the base model for SQL vector store."""
 
             __tablename__ = name
+            __table_args__ = {"schema": schema}
             __table_args__ = {"schema": schema}
             id = Column(Uuid, primary_key=True, default=uuid.uuid4)
             custom_id = Column(VARCHAR, nullable=True)  # column for user defined ids.
@@ -341,6 +344,7 @@ class SQLServer_VectorStore(VectorStore):
                 session.commit()
 
             logging.info(f"Vector store `{self.table_name}` dropped successfully.")
+
         except ProgrammingError as e:
             logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -120,7 +120,7 @@ class SQLServer_VectorStore(VectorStore):
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
         embedding_function: Embeddings,
-        embedding_length: Optional[int] = None,
+        embedding_length: int,
         table_name: str,
     ) -> None:
         """Initialize the SQL Server vector store.
@@ -138,11 +138,8 @@ class SQLServer_VectorStore(VectorStore):
             embedding_function: Any embedding function implementing
                 `langchain.embeddings.base.Embeddings` interface.
             embedding_length: The length (dimension) of the vectors to be stored in the
-                table. Default - None.
-                Note that if `embedding_length` is defined, only vectors of the same
-                size will be accepted. If not defined, vectors of different sizes can
-                be stored in the table, however, similarity search will not be possible
-                against the vector store.
+                table.
+                Note that only vectors of same size can be added to the vector store.
             table_name: The name of the table to use for storing embeddings.
 
         """
@@ -187,21 +184,18 @@ class SQLServer_VectorStore(VectorStore):
             content_metadata = Column(JSON, nullable=True)
             content = Column(NVARCHAR, nullable=False)  # defaults to NVARCHAR(MAX)
 
-            if self._embedding_length:
-                # Add check constraint to embeddings column
-                # this will ensure only vectors of the same size
-                # are allowed in the vector store.
-                embeddings = Column(
-                    VARBINARY(8000),
-                    CheckConstraint(
-                        text(EMBEDDING_LENGTH_CONSTRAINT).bindparams(
-                            bindparam(EMBEDDING_LENGTH, self._embedding_length)
-                        )
-                    ),
-                    nullable=False,
-                )
-            else:
-                embeddings = Column(VARBINARY(8000), nullable=False)
+            # Add check constraint to embeddings column
+            # this will ensure only vectors of the same size
+            # are allowed in the vector store.
+            embeddings = Column(
+                VARBINARY(8000),
+                CheckConstraint(
+                    text(EMBEDDING_LENGTH_CONSTRAINT).bindparams(
+                        bindparam(EMBEDDING_LENGTH, self._embedding_length)
+                    )
+                ),
+                nullable=False,
+            )
 
         return EmbeddingStore
 

--- a/libs/community/tests/integration_tests/vectorstores/fixtures/filtering_test_cases.py
+++ b/libs/community/tests/integration_tests/vectorstores/fixtures/filtering_test_cases.py
@@ -41,7 +41,7 @@ metadatas = [
     },
 ]
 texts = ["id {id}".format(id=metadata["id"]) for metadata in metadatas]
-
+IDS = [str(metadata["id"]) for metadata in metadatas]
 DOCUMENTS = [
     Document(page_content=text, metadata=metadata)
     for text, metadata in zip(texts, metadatas)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -35,7 +35,6 @@ _COLLATION_DB_NAME = "LangChainCollationTest"
 _TABLE_NAME = "langchain_vector_store_tests"
 _TABLE_DOES_NOT_EXIST = "Table %s.%s does not exist."
 EMBEDDING_LENGTH = 1536
-VECTOR_STORE_TABLE_NAME = "langchain_vector_store_test"
 
 # Query Strings
 #
@@ -57,7 +56,7 @@ def store() -> Generator[SQLServer_VectorStore, None, None]:
         embedding_length=EMBEDDING_LENGTH,
         # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
         embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
-        table_name=VECTOR_STORE_TABLE_NAME,
+        table_name=_TABLE_NAME,
     )
     yield store  # provide this data to the test
 
@@ -349,7 +348,8 @@ def test_that_multiple_vector_stores_can_be_created(
     # Create another vector store with a different table name.
     new_store = SQLServer_VectorStore(
         connection_string=_CONNECTION_STRING,
-        embedding_function=FakeEmbeddings(size=1536),
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        embedding_length=EMBEDDING_LENGTH,
         table_name="langchain_vector_store_tests_2",
     )
 
@@ -373,7 +373,8 @@ def test_that_schema_input_is_used() -> None:
         connection=connection,
         connection_string=_CONNECTION_STRING,
         db_schema=_SCHEMA,
-        embedding_function=FakeEmbeddings(size=1536),
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        embedding_length=EMBEDDING_LENGTH,
         table_name=_TABLE_NAME,
     )
     sqlserver_vectorstore.add_texts(["cats"])
@@ -396,7 +397,8 @@ def test_that_same_name_vector_store_can_be_created_in_different_schemas() -> No
         connection=connection,
         connection_string=_CONNECTION_STRING,
         db_schema=_SCHEMA,
-        embedding_function=FakeEmbeddings(size=1536),
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        embedding_length=EMBEDDING_LENGTH,
         table_name=_TABLE_NAME,
     )
 
@@ -404,7 +406,8 @@ def test_that_same_name_vector_store_can_be_created_in_different_schemas() -> No
     sqlserver_vectorstore_default_schema = SQLServer_VectorStore(
         connection=connection,
         connection_string=_CONNECTION_STRING,
-        embedding_function=FakeEmbeddings(size=1536),
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        embedding_length=EMBEDDING_LENGTH,
         table_name=_TABLE_NAME,
     )
 
@@ -428,28 +431,21 @@ def test_that_same_name_vector_store_can_be_created_in_different_schemas() -> No
     connection.close()
 
 
-def test_that_any_size_of_embeddings_can_be_added_when_embedding_length_is_not_defined(
+def test_that_only_same_size_embeddings_can_be_added_to_store(
+    store: SQLServer_VectorStore,
     texts: List[str],
 ) -> None:
-    """Tests that when embedding_length is not provided, the vector store can
-    take vectors of varying dimensions."""
+    """Tests that when embedding_length is provided, the vector store can
+    take only vectors of same dimensions."""
     # Create a SQLServer_VectorStore without `embedding_length` defined.
-    store_without_length = SQLServer_VectorStore(
-        connection_string=_CONNECTION_STRING,
-        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
-        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
-        table_name="langchain_test_table_no_embedding_length",
-    )
-    store_without_length.add_texts(texts)
+    store.add_texts(texts)
 
     # Add texts using an embedding function with a different length.
-    # This should not raise an exception.
+    # This should raise an exception.
     #
-    store_without_length.embedding_function = FakeEmbeddings(size=420)
-    store_without_length.add_texts(texts)
-
-    # Drop the vector store when done to cleanup this testcase resource.
-    store_without_length.drop()
+    store.embedding_function = FakeEmbeddings(size=420)
+    with pytest.raises(Exception):
+        store.add_texts(texts)
 
 
 def test_that_similarity_search_returns_expected_no_of_documents(

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine, text
 
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores.sqlserver import (
+    DistanceStrategy,
     SQLServer_VectorStore,
 )
 from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
@@ -30,16 +31,22 @@ from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
 
 _CONNECTION_STRING = str(os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING"))
 _SCHEMA = "lc_test"
-# _DATABASE_NAME = "LangChainVectors"
-# _COLLATION_QUERY = "select name, collation_name from
-#  sys.databases where name = N'%s';"
-_SYS_TABLE_QUERY = """
-select object_id from sys.tables where name = '%s'
-and schema_name(schema_id) = '%s'"""
+_COLLATION_DB_NAME = "LangChainCollationTest"
 _TABLE_NAME = "langchain_vector_store_tests"
 _TABLE_DOES_NOT_EXIST = "Table %s.%s does not exist."
 EMBEDDING_LENGTH = 1536
 VECTOR_STORE_TABLE_NAME = "langchain_vector_store_test"
+
+# Query Strings
+#
+_CREATE_COLLATION_DB_QUERY = (
+    f"create database {_COLLATION_DB_NAME} collate SQL_Latin1_General_CP1_CS_AS;"
+)
+_COLLATION_QUERY = "select name, collation_name from sys.databases where name = N'%s';"
+_DROP_COLLATION_DB_QUERY = f"drop database {_COLLATION_DB_NAME}"
+_SYS_TABLE_QUERY = """
+select object_id from sys.tables where name = '%s'
+and schema_name(schema_id) = '%s'"""
 
 
 @pytest.fixture
@@ -593,3 +600,51 @@ def test_invalid_filters(
     """Verify that invalid filters raise an error."""
     with pytest.raises(ValueError):
         store._create_filter_clause(invalid_filter)
+    
+
+def test_that_case_sensitivity_does_not_affect_distance_strategy(
+    texts: List[str],
+) -> None:
+    """Test that when distance strategy is set on a case sensitive DB,
+    a call to similarity search does not fail."""
+    connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
+
+    conn = create_engine(connection_string_to_master).connect()
+    conn.rollback()
+
+    if conn.connection.dbapi_connection is not None:
+        conn.connection.dbapi_connection.autocommit = True
+
+    conn.execute(text(_CREATE_COLLATION_DB_QUERY))
+    conn.execute(text(f"use {_COLLATION_DB_NAME}"))
+
+    store = SQLServer_VectorStore(
+        connection=conn,
+        connection_string=connection_string_to_master,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_length=EMBEDDING_LENGTH,
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
+    collation_query_result = (
+        conn.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
+    )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
+
+    assert (
+        collation_query_result is not None
+    ), "No collation data returned from the database."
+    # Confirm DB is case sensitive
+    assert "_CS" in collation_query_result.collation_name
+
+    store.add_texts(texts)
+    store._distance_strategy = DistanceStrategy.DOT
+
+    # Call to similarity_search function should not error out.
+    number_of_docs_to_return = 2
+    result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
+    assert result is not None and len(result) == number_of_docs_to_return
+
+    # Drop DB with case sensitive collation for test.
+    conn.execute(text("use master"))
+    conn.execute(text(_DROP_COLLATION_DB_QUERY))
+    conn.close()

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -1,7 +1,7 @@
 """Test SQLServer_VectorStore functionality."""
 
 import os
-from typing import Generator, List
+from typing import Any, Dict, Generator, List
 
 import pytest
 from langchain_core.documents import Document
@@ -9,14 +9,30 @@ from sqlalchemy import create_engine, text
 
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores.sqlserver import (
-    DistanceStrategy,
     SQLServer_VectorStore,
+)
+from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
+    IDS as filter_ids,
+)
+from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
+    TYPE_1_FILTERING_TEST_CASES,
+    TYPE_2_FILTERING_TEST_CASES,
+    TYPE_3_FILTERING_TEST_CASES,
+    TYPE_4_FILTERING_TEST_CASES,
+    TYPE_5_FILTERING_TEST_CASES,
+)
+from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
+    metadatas as filter_metadatas,
+)
+from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
+    texts as filter_texts,
 )
 
 _CONNECTION_STRING = str(os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING"))
 _SCHEMA = "lc_test"
-_DATABASE_NAME = "LangChainVectors"
-_COLLATION_QUERY = "select name, collation_name from sys.databases where name = N'%s';"
+# _DATABASE_NAME = "LangChainVectors"
+# _COLLATION_QUERY = "select name, collation_name from
+#  sys.databases where name = N'%s';"
 _SYS_TABLE_QUERY = """
 select object_id from sys.tables where name = '%s'
 and schema_name(schema_id) = '%s'"""
@@ -457,29 +473,123 @@ def test_that_similarity_search_returns_results_with_scores_sorted_in_ascending_
     assert doc_with_score == sorted(doc_with_score, key=lambda x: x[1])
 
 
-def test_that_case_sensitivity_does_not_affect_distance_strategy(
+# def test_that_case_sensitivity_does_not_affect_distance_strategy(
+#     store: SQLServer_VectorStore,
+#     texts: List[str],
+# ) -> None:
+#     """Test that when distance strategy is set on a case sensitive DB,
+#     a call to similarity search does not fail."""
+
+#     connection = create_engine(_CONNECTION_STRING).connect()
+#     collation_query_result = (
+#         connection.execute(text(_COLLATION_QUERY % (_DATABASE_NAME))).fetchone()
+#     )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
+#     connection.close()
+
+#     assert (
+#         collation_query_result is not None
+#     ), "No collation data returned from the database."
+#     # Confirm DB is case sensitive
+#     assert "_CS" in collation_query_result.collation_name
+
+#     store.add_texts(texts)
+#     store._distance_strategy = DistanceStrategy.DOT
+
+#     # Call to similarity_search function should not error out.
+#     number_of_docs_to_return = 2
+#     result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
+#     assert result is not None and len(result) == number_of_docs_to_return
+
+
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_1_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_1(
     store: SQLServer_VectorStore,
-    texts: List[str],
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
 ) -> None:
-    """Test that when distance strategy is set on a case sensitive DB,
-    a call to similarity search does not fail."""
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
 
-    connection = create_engine(_CONNECTION_STRING).connect()
-    collation_query_result = (
-        connection.execute(text(_COLLATION_QUERY % (_DATABASE_NAME))).fetchone()
-    )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
-    connection.close()
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
 
-    assert (
-        collation_query_result is not None
-    ), "No collation data returned from the database."
-    # Confirm DB is case sensitive
-    assert "_CS" in collation_query_result.collation_name
 
-    store.add_texts(texts)
-    store._distance_strategy = DistanceStrategy.DOT
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_2_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_2(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
+) -> None:
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
 
-    # Call to similarity_search function should not error out.
-    number_of_docs_to_return = 2
-    result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
-    assert result is not None and len(result) == number_of_docs_to_return
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
+
+
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_3_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_3(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
+) -> None:
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
+
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
+
+
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_4_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_4(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
+) -> None:
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
+
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
+
+
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_5_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_5(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
+) -> None:
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
+
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
+
+
+@pytest.mark.parametrize(
+    "invalid_filter",
+    [
+        ["hello"],
+        {
+            "id": 2,
+            "$name": "foo",
+        },
+        {"$or": {}},
+        {"$and": {}},
+        {"$between": {}},
+        {"$eq": {}},
+    ],
+)
+def test_invalid_filters(
+    store: SQLServer_VectorStore, invalid_filter: Dict[str, Any]
+) -> None:
+    """Verify that invalid filters raise an error."""
+    with pytest.raises(ValueError):
+        store._create_filter_clause(invalid_filter)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -476,32 +476,52 @@ def test_that_similarity_search_returns_results_with_scores_sorted_in_ascending_
     assert doc_with_score == sorted(doc_with_score, key=lambda x: x[1])
 
 
-# def test_that_case_sensitivity_does_not_affect_distance_strategy(
-#     store: SQLServer_VectorStore,
-#     texts: List[str],
-# ) -> None:
-#     """Test that when distance strategy is set on a case sensitive DB,
-#     a call to similarity search does not fail."""
+def test_that_case_sensitivity_does_not_affect_distance_strategy(
+    texts: List[str],
+) -> None:
+    """Test that when distance strategy is set on a case sensitive DB,
+    a call to similarity search does not fail."""
+    connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
 
-#     connection = create_engine(_CONNECTION_STRING).connect()
-#     collation_query_result = (
-#         connection.execute(text(_COLLATION_QUERY % (_DATABASE_NAME))).fetchone()
-#     )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
-#     connection.close()
+    conn = create_engine(connection_string_to_master).connect()
+    conn.rollback()
 
-#     assert (
-#         collation_query_result is not None
-#     ), "No collation data returned from the database."
-#     # Confirm DB is case sensitive
-#     assert "_CS" in collation_query_result.collation_name
+    if conn.connection.dbapi_connection is not None:
+        conn.connection.dbapi_connection.autocommit = True
 
-#     store.add_texts(texts)
-#     store._distance_strategy = DistanceStrategy.DOT
+    conn.execute(text(_CREATE_COLLATION_DB_QUERY))
+    conn.execute(text(f"use {_COLLATION_DB_NAME}"))
 
-#     # Call to similarity_search function should not error out.
-#     number_of_docs_to_return = 2
-#     result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
-#     assert result is not None and len(result) == number_of_docs_to_return
+    store = SQLServer_VectorStore(
+        connection=conn,
+        connection_string=connection_string_to_master,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_length=EMBEDDING_LENGTH,
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
+    collation_query_result = (
+        conn.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
+    )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
+
+    assert (
+        collation_query_result is not None
+    ), "No collation data returned from the database."
+    # Confirm DB is case sensitive
+    assert "_CS" in collation_query_result.collation_name
+
+    store.add_texts(texts)
+    store._distance_strategy = DistanceStrategy.DOT
+
+    # Call to similarity_search function should not error out.
+    number_of_docs_to_return = 2
+    result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
+    assert result is not None and len(result) == number_of_docs_to_return
+
+    # Drop DB with case sensitive collation for test.
+    conn.execute(text("use master"))
+    conn.execute(text(_DROP_COLLATION_DB_QUERY))
+    conn.close()
 
 
 @pytest.mark.parametrize("test_filter, expected_ids", TYPE_1_FILTERING_TEST_CASES)
@@ -596,51 +616,3 @@ def test_invalid_filters(
     """Verify that invalid filters raise an error."""
     with pytest.raises(ValueError):
         store._create_filter_clause(invalid_filter)
-    
-
-def test_that_case_sensitivity_does_not_affect_distance_strategy(
-    texts: List[str],
-) -> None:
-    """Test that when distance strategy is set on a case sensitive DB,
-    a call to similarity search does not fail."""
-    connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
-
-    conn = create_engine(connection_string_to_master).connect()
-    conn.rollback()
-
-    if conn.connection.dbapi_connection is not None:
-        conn.connection.dbapi_connection.autocommit = True
-
-    conn.execute(text(_CREATE_COLLATION_DB_QUERY))
-    conn.execute(text(f"use {_COLLATION_DB_NAME}"))
-
-    store = SQLServer_VectorStore(
-        connection=conn,
-        connection_string=connection_string_to_master,
-        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
-        embedding_length=EMBEDDING_LENGTH,
-        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
-        table_name=_TABLE_NAME,
-    )
-    collation_query_result = (
-        conn.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
-    )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
-
-    assert (
-        collation_query_result is not None
-    ), "No collation data returned from the database."
-    # Confirm DB is case sensitive
-    assert "_CS" in collation_query_result.collation_name
-
-    store.add_texts(texts)
-    store._distance_strategy = DistanceStrategy.DOT
-
-    # Call to similarity_search function should not error out.
-    number_of_docs_to_return = 2
-    result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
-    assert result is not None and len(result) == number_of_docs_to_return
-
-    # Drop DB with case sensitive collation for test.
-    conn.execute(text("use master"))
-    conn.execute(text(_DROP_COLLATION_DB_QUERY))
-    conn.close()


### PR DESCRIPTION
## Why make this change?
This PR contains implementation for hybrid search.

## What is this change?
This PR contains the following implementations / changes:

```    
def _create_filter_clause(self, filters: dict) -> None:
        """Convert LangChain IR filter representation to matching SQLAlchemy clauses.

        At the top level, we still don't know if we're working with a field
        or an operator for the keys. After we've determined that we can
        call the appropriate logic to handle filter creation.

        Args:
            filters: Dictionary of filters to apply to the query.

        Returns:
            SQLAlchemy clause to apply to the query.
```
This functions creates an SQLAlchemy filter cluase based on the filter input given. It also has a helper function.

```
def _handle_field_filter(
        self,
        field: str,
        value: Any,
    ) -> SQLColumnExpression:
        """Create a filter for a specific field.

        Args:
            field: name of field
            value: value to filter
                If provided as is then this will be an equality filter
                If provided as a dictionary then this will be a filter, the key
                will be the operator and the value will be the value to filter by

        Returns:
            sqlalchemy expression
        """
```
This helper function handles the field filter conversion, where you have a field and respective filter for that field.

## What Filters are supported?

The vectorstore supports a set of filters that can be applied against the metadata fields of the documents.

\$eq | Equality (==)
\$ne | Inequality (!=)
\$lt | Less than (<)
\$lte | Less than or equal (<=)
\$gt | Greater than (>)
\$gte | Greater than or equal (>=)
\$in | Special Cased (in)
\$nin | Special Cased (not in)
\$between | Special Cased (between)
\$like | Text (like)
\$ilike | Text (case-insensitive like)
\$and | Logical (and)
\$or | Logical (or)


## What are some sample filters?

`filter={
        "$and": [
            {"id": {"$in": [1, 5, 2, 9]}},
            {"location": {"$in": ["pond", "market"]}},
        ]
    }`

`filter={"id": {"$in": [1, 5, 2, 9]}, "location": {"$in": ["pond", "market"]}}`

`filter={"id": {"$in": [1, 5, 2, 9]}}`


## How was this tested?
We have used the standard test cases provided in 
`C:\SQLTeamProjects\LangChainRepo\langchain\libs\community\tests\integration_tests\vectorstores\fixtures\filtering_test_cases.py`  for testing purposes. These tests cover a wide range of filter choices as below:

```
1. equality checks
2. String field
3. Boolean fields
4. And semantics for top level filtering
5. equality checks and other operators like $ne, $gt, $gte, $lt, $lte, $not
6. gt, gte, lt, lte relying on lexicographical ordering
7. float column
8. AND and OR operators
9. special operators like $in, $nin, $between
10. special operators like $like, $ilike

Also, a few filters was used to check possible failure cases.
```
<img width="1648" alt="image" src="https://github.com/user-attachments/assets/cd6f5b2c-a663-4217-b474-68417918d7e4">

NB: These tests will be moved in a later PR to the integration test folder and proper unit tests will be created also.


