### PR TITLE
Hybrid search implementation

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -104,13 +104,11 @@ EMPTY_IDS_ERROR_MESSAGE = "Empty list of ids provided"
 EXTRA_PARAMS = ";Trusted_Connection=Yes"
 INVALID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
 INVALID_INPUT_ERROR_MESSAGE = "Input is not valid."
-<<<<<<< HEAD
 INVALID_FILTER_INPUT_EXPECTED_DICT = "Invalid filter condition. Expected a dictionary "
 "but got an empty dictionary"
 INVALID_FILTER_INPUT_EXPECTED_AND_OR = "Invalid filter condition."
 "Expected $and or $or but got: {}"
 
-=======
 SQL_COPT_SS_ACCESS_TOKEN = 1256  # Connection option defined by microsoft in msodbcsql.h
 
 # Query Constants
@@ -227,7 +225,6 @@ class SQLServer_VectorStore(VectorStore):
             """This is the base model for SQL vector store."""
 
             __tablename__ = name
-            __table_args__ = {"schema": schema}
             __table_args__ = {"schema": schema}
             id = Column(Uuid, primary_key=True, default=uuid.uuid4)
             custom_id = Column(VARCHAR, nullable=True)  # column for user defined ids.

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -30,7 +30,6 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
-import copy
 import json
 import logging
 import uuid

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import (
     Any,
+    Callable,
+    Dict,
     Iterable,
     List,
     MutableMapping,
@@ -18,16 +20,16 @@ from sqlalchemy import (
     CheckConstraint,
     Column,
     ColumnElement,
+    Dialect,
     Numeric,
     SQLColumnExpression,
-    Dialect,
     Uuid,
     asc,
     bindparam,
     cast,
-    cast,
     create_engine,
     event,
+    func,
     label,
     text,
 )
@@ -35,8 +37,8 @@ from sqlalchemy.dialects.mssql import JSON, NVARCHAR, VARBINARY, VARCHAR
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import operators
 from sqlalchemy.pool import ConnectionPoolEntry
+from sqlalchemy.sql import operators
 
 try:
     from sqlalchemy.orm import declarative_base

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -106,10 +106,10 @@ EMPTY_IDS_ERROR_MESSAGE = "Empty list of ids provided"
 EXTRA_PARAMS = ";Trusted_Connection=Yes"
 INVALID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
 INVALID_INPUT_ERROR_MESSAGE = "Input is not valid."
-INVALID_FILTER_INPUT_EXPECTED_DICT = "Invalid filter condition. Expected a dictionary "
-"but got an empty dictionary"
-INVALID_FILTER_INPUT_EXPECTED_AND_OR = "Invalid filter condition."
-"Expected $and or $or but got: {}"
+INVALID_FILTER_INPUT_EXPECTED_DICT = """Invalid filter condition. Expected a dictionary "
+but got an empty dictionary"""
+INVALID_FILTER_INPUT_EXPECTED_AND_OR = """Invalid filter condition."
+Expected $and or $or but got: {}"""
 
 SQL_COPT_SS_ACCESS_TOKEN = 1256  # Connection option defined by microsoft in msodbcsql.h
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -536,10 +536,8 @@ class SQLServer_VectorStore(VectorStore):
         Returns:
             sqlalchemy expression
 
-        Ex: For a filter,  {"$or": [{"id": 1}, {"name": "bob"}]}, the result is
+        Ex: For a filter,  {"id": 1}, the result is
 
-            JSON_VALUE(langchain_vector_store_tests.content_metadata, :JSON_VALUE_1) =
-              :JSON_VALUE_2
             JSON_VALUE(langchain_vector_store_tests.content_metadata, :JSON_VALUE_1) =
               :JSON_VALUE_2
         """

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,10 +1,6 @@
 from enum import Enum
-<<<<<<< HEAD
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
-=======
-from typing import Any, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Iterable, List, MutableMapping, Optional, Tuple, Type, Union
 from urllib.parse import urlparse
->>>>>>> c7894f1c6 (use entra id or normal sql connection auth)
 
 from azure.identity import DefaultAzureCredential
 from langchain_core.documents import Document
@@ -16,16 +12,13 @@ from sqlalchemy import (
     ColumnElement,
     Numeric,
     SQLColumnExpression,
+    Dialect,
     Uuid,
     asc,
     bindparam,
     cast,
     create_engine,
-<<<<<<< HEAD
-    func,
-=======
     event,
->>>>>>> c7894f1c6 (use entra id or normal sql connection auth)
     label,
     text,
 )
@@ -34,6 +27,7 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import operators
+from sqlalchemy.pool import ConnectionPoolEntry
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -109,7 +103,6 @@ INVALID_FILTER_INPUT_EXPECTED_AND_OR = "Invalid filter condition."
 
 =======
 SQL_COPT_SS_ACCESS_TOKEN = 1256  # Connection option defined by microsoft in msodbcsql.h
->>>>>>> c7894f1c6 (use entra id or normal sql connection auth)
 
 # Query Constants
 #
@@ -383,7 +376,6 @@ class SQLServer_VectorStore(VectorStore):
                 session.commit()
 
             logging.info(f"Vector store `{self.table_name}` dropped successfully.")
-
         except ProgrammingError as e:
             logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
 
@@ -775,7 +767,13 @@ class SQLServer_VectorStore(VectorStore):
             logging.error(e.__cause__)
         return result
 
-    def _provide_token(self, dialect, conn_rec, cargs, cparams) -> None:
+    def _provide_token(
+        self,
+        dialect: Dialect,
+        conn_rec: Optional[ConnectionPoolEntry],
+        cargs: List[str],
+        cparams: MutableMapping[str, Any],
+    ) -> None:
         """Get token for SQLServer connection from token URL,
         and use the token to connect to the database."""
         credential = DefaultAzureCredential()

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -136,7 +136,6 @@ class SQLServer_VectorStore(VectorStore):
         connection_string: str,
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
-        db_schema: Optional[str] = None,
         embedding_function: Embeddings,
         embedding_length: int,
         table_name: str,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -106,7 +106,7 @@ EMPTY_IDS_ERROR_MESSAGE = "Empty list of ids provided"
 EXTRA_PARAMS = ";Trusted_Connection=Yes"
 INVALID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
 INVALID_INPUT_ERROR_MESSAGE = "Input is not valid."
-INVALID_FILTER_INPUT_EXPECTED_DICT = """Invalid filter condition. Expected a dictionary "
+INVALID_FILTER_INPUT_EXPECTED_DICT = """Invalid filter condition. Expected a dictionary
 but got an empty dictionary"""
 INVALID_FILTER_INPUT_EXPECTED_AND_OR = """Invalid filter condition."
 Expected $and or $or but got: {}"""
@@ -442,7 +442,7 @@ class SQLServer_VectorStore(VectorStore):
         """Convert LangChain Information Retrieval filter representation to matching
         SQLAlchemy clauses.
 
-        At the top level,we still don't know if we're working with a field
+        At the top level, we still don't know if we're working with a field
         or an operator for the keys. After we've determined that we can
         call the appropriate logic to handle filter creation.
 
@@ -640,7 +640,7 @@ class SQLServer_VectorStore(VectorStore):
             elif operator in {"$like"}:
                 return queried_field.like(str(filter_value))
             else:
-                raise NotImplementedError(f"Operator is not implemnted: {operator}. ")
+                raise NotImplementedError(f"Operator is not implemented: {operator}. ")
         else:
             raise NotImplementedError()
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -43,6 +43,7 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
+import copy
 import json
 import logging
 import struct
@@ -136,6 +137,7 @@ class SQLServer_VectorStore(VectorStore):
         connection_string: str,
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
+        db_schema: Optional[str] = None,
         embedding_function: Embeddings,
         embedding_length: int,
         table_name: str,
@@ -227,6 +229,7 @@ class SQLServer_VectorStore(VectorStore):
             """This is the base model for SQL vector store."""
 
             __tablename__ = name
+            __table_args__ = {"schema": schema}
             __table_args__ = {"schema": schema}
             id = Column(Uuid, primary_key=True, default=uuid.uuid4)
             custom_id = Column(VARCHAR, nullable=True)  # column for user defined ids.
@@ -394,6 +397,7 @@ class SQLServer_VectorStore(VectorStore):
                 session.commit()
 
             logging.info(f"Vector store `{self.table_name}` dropped successfully.")
+
         except ProgrammingError as e:
             logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -108,7 +108,7 @@ INVALID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
 INVALID_INPUT_ERROR_MESSAGE = "Input is not valid."
 INVALID_FILTER_INPUT_EXPECTED_DICT = """Invalid filter condition. Expected a dictionary
 but got an empty dictionary"""
-INVALID_FILTER_INPUT_EXPECTED_AND_OR = """Invalid filter condition
+INVALID_FILTER_INPUT_EXPECTED_AND_OR = """Invalid filter condition.
 Expected $and or $or but got: {}"""
 
 SQL_COPT_SS_ACCESS_TOKEN = 1256  # Connection option defined by microsoft in msodbcsql.h

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -119,7 +119,6 @@ class SQLServer_VectorStore(VectorStore):
         connection_string: str,
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
-        db_schema: Optional[str] = None,
         embedding_function: Embeddings,
         embedding_length: int,
         table_name: str,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -108,7 +108,7 @@ INVALID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
 INVALID_INPUT_ERROR_MESSAGE = "Input is not valid."
 INVALID_FILTER_INPUT_EXPECTED_DICT = """Invalid filter condition. Expected a dictionary
 but got an empty dictionary"""
-INVALID_FILTER_INPUT_EXPECTED_AND_OR = """Invalid filter condition."
+INVALID_FILTER_INPUT_EXPECTED_AND_OR = """Invalid filter condition
 Expected $and or $or but got: {}"""
 
 SQL_COPT_SS_ACCESS_TOKEN = 1256  # Connection option defined by microsoft in msodbcsql.h

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,8 +1,16 @@
 from enum import Enum
-from typing import Any, Iterable, List, MutableMapping, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Iterable,
+    List,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 from urllib.parse import urlparse
 
-from azure.identity import DefaultAzureCredential
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VST, VectorStore
@@ -776,6 +784,8 @@ class SQLServer_VectorStore(VectorStore):
     ) -> None:
         """Get token for SQLServer connection from token URL,
         and use the token to connect to the database."""
+        from azure.identity import DefaultAzureCredential
+
         credential = DefaultAzureCredential()
 
         # Remove Trusted_Connection param that SQLAlchemy adds to

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -30,6 +30,7 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
+import copy
 import json
 import logging
 import uuid
@@ -119,6 +120,7 @@ class SQLServer_VectorStore(VectorStore):
         connection_string: str,
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
+        db_schema: Optional[str] = None,
         embedding_function: Embeddings,
         embedding_length: int,
         table_name: str,
@@ -178,6 +180,7 @@ class SQLServer_VectorStore(VectorStore):
             """This is the base model for SQL vector store."""
 
             __tablename__ = name
+            __table_args__ = {"schema": schema}
             __table_args__ = {"schema": schema}
             id = Column(Uuid, primary_key=True, default=uuid.uuid4)
             custom_id = Column(VARCHAR, nullable=True)  # column for user defined ids.
@@ -345,6 +348,7 @@ class SQLServer_VectorStore(VectorStore):
                 session.commit()
 
             logging.info(f"Vector store `{self.table_name}` dropped successfully.")
+
         except ProgrammingError as e:
             logging.error(f"Unable to drop vector store.\n {e.__cause__}.")
 

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
@@ -7,10 +7,15 @@ from langchain_core.vectorstores import VST, VectorStore
 from sqlalchemy import (
     CheckConstraint,
     Column,
+    ColumnElement,
+    Numeric,
+    SQLColumnExpression,
     Uuid,
     asc,
     bindparam,
+    cast,
     create_engine,
+    func,
     label,
     text,
 )
@@ -18,6 +23,7 @@ from sqlalchemy.dialects.mssql import JSON, NVARCHAR, VARBINARY, VARCHAR
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import operators
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -27,6 +33,45 @@ except ImportError:
 import json
 import logging
 import uuid
+
+import sqlalchemy
+
+_embedding_store: Any = None  # One vector store used for the entirety of the program.
+
+Base = declarative_base()  # type: Any
+
+COMPARISONS_TO_NATIVE: Dict[str, Callable[[ColumnElement, object], ColumnElement]] = {
+    "$eq": operators.eq,
+    "$ne": operators.ne,
+}
+
+NUMERIC_OPERATORS: Dict[str, Callable[[ColumnElement, object], ColumnElement]] = {
+    "$lt": operators.lt,
+    "$lte": operators.le,
+    "$gt": operators.gt,
+    "$gte": operators.ge,
+}
+
+SPECIAL_CASED_OPERATORS = {
+    "$in",
+    "$nin",
+    "$between",
+}
+
+TEXT_OPERATORS = {
+    "$like",
+    "$ilike",
+}
+
+LOGICAL_OPERATORS = {"$and", "$or"}
+
+SUPPORTED_OPERATORS = (
+    set(COMPARISONS_TO_NATIVE)
+    .union(NUMERIC_OPERATORS)
+    .union(SPECIAL_CASED_OPERATORS)
+    .union(TEXT_OPERATORS)
+    .union(LOGICAL_OPERATORS)
+)
 
 
 class DistanceStrategy(str, Enum):
@@ -308,6 +353,11 @@ class SQLServer_VectorStore(VectorStore):
     ) -> List[Any]:
         try:
             with Session(self._bind) as session:
+                filter_by = []
+                filter_clauses = self._create_filter_clause(filter)
+                if filter_clauses is not None:
+                    filter_by.append(filter_clauses)
+
                 results = (
                     session.query(
                         self._embedding_store,
@@ -327,7 +377,7 @@ class SQLServer_VectorStore(VectorStore):
                             ),
                         ),
                     )
-                    .filter()
+                    .filter(*filter_by)
                     .order_by(asc(text(DISTANCE)))
                     .limit(k)
                     .all()
@@ -338,12 +388,230 @@ class SQLServer_VectorStore(VectorStore):
 
         return results
 
-    def _create_filter_clause(self, filter: dict) -> None:
-        """TODO: parse filter and create a sql clause."""
+    def _create_filter_clause(self, filters: Any) -> Any:
+        """Convert LangChain IR filter representation to matching SQLAlchemy clauses.
 
-    def _docs_from_result(
-        self, results: List[Tuple[Document, float]]
-    ) -> List[Document]:
+        At the top level,we still don't know if we're working with a field
+        or an operator for the keys. After we've determined that we can
+        call the appropriate logic to handle filter creation.
+
+        Args:
+            filters: Dictionary of filters to apply to the query.
+
+        Returns:
+            SQLAlchemy clause to apply to the query.
+        """
+        if filters is not None:
+            # Here we want a list of filters instead of dict
+            if not isinstance(filters, dict):
+                raise ValueError(
+                    f"Expected a dict, but got {type(filters)} for value: {filter}"
+                )
+            if len(filters) == 1:
+                # The only operators allowed at the top level are $AND and $OR
+                # First check if an operator or a field
+                key, value = list(filters.items())[0]
+                if key.startswith("$"):
+                    # Then it's an operator
+                    if key.lower() not in ["$and", "$or"]:
+                        raise ValueError(
+                            f"Invalid filter condition. Expected $and or $or "
+                            f"but got: {key}"
+                        )
+                else:
+                    # Then it's a field
+                    return self._handle_field_filter(key, filters[key])
+
+                # Here we handle the $and and $or operators
+                if not isinstance(value, list):
+                    raise ValueError(
+                        f"Expected a list, but got {type(value)} for value: {value}"
+                    )
+                if key.lower() == "$and":
+                    and_ = [self._create_filter_clause(el) for el in value]
+                    if len(and_) > 1:
+                        return sqlalchemy.and_(*and_)
+                    elif len(and_) == 1:
+                        return and_[0]
+                    else:
+                        raise ValueError(
+                            "Invalid filter condition. Expected a dictionary "
+                            "but got an empty dictionary"
+                        )
+                elif key.lower() == "$or":
+                    or_ = [self._create_filter_clause(el) for el in value]
+                    if len(or_) > 1:
+                        return sqlalchemy.or_(*or_)
+                    elif len(or_) == 1:
+                        return or_[0]
+                    else:
+                        raise ValueError(
+                            "Invalid filter condition. Expected a dictionary "
+                            "but got an empty dictionary"
+                        )
+
+                else:
+                    raise ValueError(
+                        f"Invalid filter condition. Expected $and or $or "
+                        f"but got: {key}"
+                    )
+
+            elif len(filters) > 1:
+                # Then all keys have to be fields (they cannot be operators)
+                for key in filters.keys():
+                    if key.startswith("$"):
+                        raise ValueError(
+                            f"Invalid filter condition. Expected a field but got: {key}"
+                        )
+                # These should all be fields and combined using an $and operator
+                and_ = [self._handle_field_filter(k, v) for k, v in filters.items()]
+                if len(and_) > 1:
+                    return sqlalchemy.and_(*and_)
+                elif len(and_) == 1:
+                    return and_[0]
+                else:
+                    raise ValueError(
+                        "Invalid filter condition. Expected a dictionary "
+                        "but got an empty dictionary"
+                    )
+            else:
+                raise ValueError("Got an empty dictionary for filters.")
+        else:
+            logging.info("No filters are passed, returning")
+            return None
+
+    def _handle_field_filter(
+        self,
+        field: str,
+        value: Any,
+    ) -> SQLColumnExpression:
+        """Create a filter for a specific field.
+
+        Args:
+            field: name of field
+            value: value to filter
+                If provided as is then this will be an equality filter
+                If provided as a dictionary then this will be a filter, the key
+                will be the operator and the value will be the value to filter by
+
+        Returns:
+            sqlalchemy expression
+        """
+
+        if not isinstance(field, str):
+            raise ValueError(
+                f"field should be a string but got: {type(field)} with value: {field}"
+            )
+
+        if field.startswith("$"):
+            raise ValueError(
+                f"Invalid filter condition. Expected a field but got an operator: "
+                f"{field}"
+            )
+
+        # Allow [a-zA-Z0-9_], disallow $ for now until we support escape characters
+        if not field.isidentifier():
+            raise ValueError(
+                f"Invalid field name: {field}. Expected a valid identifier."
+            )
+
+        if isinstance(value, dict):
+            # This is a filter specification that only 1 filter will be for a given
+            # field, if multiple filters they are mentioned separately and used with
+            # an AND on the top if nothing is specified
+            if len(value) != 1:
+                raise ValueError(
+                    "Invalid filter condition. Expected a value which "
+                    "is a dictionary with a single key that corresponds to an operator "
+                    f"but got a dictionary with {len(value)} keys. The first few "
+                    f"keys are: {list(value.keys())[:3]}"
+                )
+            operator, filter_value = list(value.items())[0]
+            # Verify that operator is an operator
+            if operator not in SUPPORTED_OPERATORS:
+                raise ValueError(
+                    f"Invalid operator: {operator}. "
+                    f"Expected one of {SUPPORTED_OPERATORS}"
+                )
+        else:  # Then we assume an equality operator
+            operator = "$eq"
+            filter_value = value
+
+        if operator in COMPARISONS_TO_NATIVE:
+            operation = COMPARISONS_TO_NATIVE[operator]
+            native_result = func.JSON_VALUE(
+                self._embedding_store.content_metadata, f"$.{field}"
+            )
+            native_operation_result = operation(native_result, str(filter_value))
+            return native_operation_result
+
+        elif operator in NUMERIC_OPERATORS:
+            operation = NUMERIC_OPERATORS[str(operator)]
+            numeric_result = func.JSON_VALUE(
+                self._embedding_store.content_metadata, f"$.{field}"
+            )
+            numeric_operation_result = operation(numeric_result, filter_value)
+
+            if not isinstance(filter_value, str):
+                numeric_operation_result = operation(
+                    cast(numeric_result, Numeric(10, 2)), filter_value
+                )
+
+            return numeric_operation_result
+
+        elif operator == "$between":
+            # Use AND with two comparisons
+            low, high = filter_value
+
+            # Assuming lower_bound_value is a ColumnElement
+            lower_bound_value = func.JSON_VALUE(
+                self._embedding_store.content_metadata, f"$.{field}"
+            )
+
+            greater_operation = NUMERIC_OPERATORS["$gte"]
+            lesser_operation = NUMERIC_OPERATORS["$lte"]
+
+            lower_bound = greater_operation(lower_bound_value, low)
+            upper_bound = lesser_operation(lower_bound_value, high)
+
+            # Conditionally cast if filter_value is not a string
+            if not isinstance(filter_value, str):
+                lower_bound = greater_operation(
+                    cast(lower_bound_value, Numeric(10, 2)), low
+                )
+                upper_bound = lesser_operation(
+                    cast(lower_bound_value, Numeric(10, 2)), high
+                )
+
+            return sqlalchemy.and_(lower_bound, upper_bound)
+
+        elif operator in {"$in", "$nin", "$like", "$ilike"}:
+            # We'll do force coercion to text
+            if operator in {"$in", "$nin"}:
+                for val in filter_value:
+                    if not isinstance(val, (str, int, float)):
+                        raise NotImplementedError(
+                            f"Unsupported type: {type(val)} for value: {val}"
+                        )
+
+            queried_field = func.JSON_VALUE(
+                self._embedding_store.content_metadata, f"$.{field}"
+            )
+
+            if operator in {"$in"}:
+                return queried_field.in_([str(val) for val in filter_value])
+            elif operator in {"$nin"}:
+                return queried_field.nin_([str(val) for val in filter_value])
+            elif operator in {"$like"}:
+                return queried_field.like(str(filter_value))
+            elif operator in {"$ilike"}:
+                return queried_field.ilike(filter_value)
+            else:
+                raise NotImplementedError()
+        else:
+            raise NotImplementedError()
+
+    def _docs_from_result(self, results: Any) -> List[Document]:
         """Formats the input into a result of type List[Document]."""
         docs = [doc for doc, _ in results if doc is not None]
         return docs

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -439,7 +439,8 @@ class SQLServer_VectorStore(VectorStore):
         return results
 
     def _create_filter_clause(self, filters: Any) -> Any:
-        """Convert LangChain IR filter representation to matching SQLAlchemy clauses.
+        """Convert LangChain Information Retrieval filter representation to matching 
+        SQLAlchemy clauses.
 
         At the top level,we still don't know if we're working with a field
         or an operator for the keys. After we've determined that we can

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -439,7 +439,7 @@ class SQLServer_VectorStore(VectorStore):
         return results
 
     def _create_filter_clause(self, filters: Any) -> Any:
-        """Convert LangChain Information Retrieval filter representation to matching 
+        """Convert LangChain Information Retrieval filter representation to matching
         SQLAlchemy clauses.
 
         At the top level,we still don't know if we're working with a field

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     asc,
     bindparam,
     cast,
+    cast,
     create_engine,
     event,
     label,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -146,6 +146,8 @@ class SQLServer_VectorStore(VectorStore):
             connection_string: SQLServer connection string.
                 If the connection string does not contain a username & password
                 or `Trusted_Connection=yes`, Entra ID authentication is used.
+                Sample connection string format:
+                "mssql+pyodbc://username:password@servername/dbname?other_params"
             db_schema: The schema in which the vector store will be created.
                 This schema must exist and the user must have permissions to the schema.
             distance_strategy: The distance strategy to use for comparing embeddings.
@@ -175,6 +177,13 @@ class SQLServer_VectorStore(VectorStore):
         self._create_table_if_not_exists()
 
     def _can_connect_with_entra_id(self) -> bool:
+        """Check the components of the connection string to determine
+        if connection via Entra ID authentication is possible or not.
+
+        The connection string is of expected to be of the form:
+            "mssql+pyodbc://username:password@servername/dbname?other_params"
+        which gets parsed into -> <scheme>://<netloc>/<path>?<query>
+        """
         parsed_url = urlparse(self.connection_string)
 
         if parsed_url is None:

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -43,7 +43,6 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
-import copy
 import json
 import logging
 import struct

--- a/libs/community/tests/integration_tests/vectorstores/fixtures/filtering_test_cases.py
+++ b/libs/community/tests/integration_tests/vectorstores/fixtures/filtering_test_cases.py
@@ -41,7 +41,7 @@ metadatas = [
     },
 ]
 texts = ["id {id}".format(id=metadata["id"]) for metadata in metadatas]
-
+IDS = [str(metadata["id"]) for metadata in metadatas]
 DOCUMENTS = [
     Document(page_content=text, metadata=metadata)
     for text, metadata in zip(texts, metadatas)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -317,6 +317,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     ]
     result = store.add_texts(texts, metadatas)
 
+    result = store.delete([])
     # Should return False, since empty list of ids given
     if not result:
         pass

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -569,6 +569,7 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     conn.execute(text(_DROP_COLLATION_DB_QUERY))
     conn.close()
 
+
 def test_sqlserver_with_no_metadata_filters(store: SQLServer_VectorStore) -> None:
     store.add_texts(filter_texts, None, filter_ids)
     try:

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -48,17 +48,19 @@ select object_id from sys.tables where name = '%s'
 and schema_name(schema_id) = '%s'"""
 
 
-FILTERING_TEST_CASES: List[Any] = [
-    filters
-    for filterList in [
-        TYPE_1_FILTERING_TEST_CASES,
-        TYPE_2_FILTERING_TEST_CASES,
-        TYPE_3_FILTERING_TEST_CASES,
-        TYPE_4_FILTERING_TEST_CASES,
-        TYPE_5_FILTERING_TEST_CASES,
-    ]
-    for filters in filterList
-]
+# Combine all test cases into one list with additional debugging
+FILTERING_TEST_CASES: List[Any] = []
+for filterList in [
+    TYPE_1_FILTERING_TEST_CASES,
+    TYPE_2_FILTERING_TEST_CASES,
+    TYPE_3_FILTERING_TEST_CASES,
+    TYPE_4_FILTERING_TEST_CASES,
+    TYPE_5_FILTERING_TEST_CASES,
+]:
+    if isinstance(filterList, list):
+        for filters in filterList:
+            if isinstance(filters, tuple):
+                FILTERING_TEST_CASES.append(filters)
 
 
 @pytest.fixture

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine, text
 
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores.sqlserver import (
+    DistanceStrategy,
     SQLServer_VectorStore,
 )
 from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
@@ -34,6 +35,17 @@ _COLLATION_DB_NAME = "LangChainCollationTest"
 _TABLE_NAME = "langchain_vector_store_tests"
 _TABLE_DOES_NOT_EXIST = "Table %s.%s does not exist."
 EMBEDDING_LENGTH = 1536
+
+# Query Strings
+#
+_CREATE_COLLATION_DB_QUERY = (
+    f"create database {_COLLATION_DB_NAME} collate SQL_Latin1_General_CP1_CS_AS;"
+)
+_COLLATION_QUERY = "select name, collation_name from sys.databases where name = N'%s';"
+_DROP_COLLATION_DB_QUERY = f"drop database {_COLLATION_DB_NAME}"
+_SYS_TABLE_QUERY = """
+select object_id from sys.tables where name = '%s'
+and schema_name(schema_id) = '%s'"""
 
 # Query Strings
 #
@@ -596,3 +608,51 @@ def test_invalid_filters(
     """Verify that invalid filters raise an error."""
     with pytest.raises(ValueError):
         store._create_filter_clause(invalid_filter)
+    
+
+def test_that_case_sensitivity_does_not_affect_distance_strategy(
+    texts: List[str],
+) -> None:
+    """Test that when distance strategy is set on a case sensitive DB,
+    a call to similarity search does not fail."""
+    connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
+
+    conn = create_engine(connection_string_to_master).connect()
+    conn.rollback()
+
+    if conn.connection.dbapi_connection is not None:
+        conn.connection.dbapi_connection.autocommit = True
+
+    conn.execute(text(_CREATE_COLLATION_DB_QUERY))
+    conn.execute(text(f"use {_COLLATION_DB_NAME}"))
+
+    store = SQLServer_VectorStore(
+        connection=conn,
+        connection_string=connection_string_to_master,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_length=EMBEDDING_LENGTH,
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
+    collation_query_result = (
+        conn.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
+    )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
+
+    assert (
+        collation_query_result is not None
+    ), "No collation data returned from the database."
+    # Confirm DB is case sensitive
+    assert "_CS" in collation_query_result.collation_name
+
+    store.add_texts(texts)
+    store._distance_strategy = DistanceStrategy.DOT
+
+    # Call to similarity_search function should not error out.
+    number_of_docs_to_return = 2
+    result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
+    assert result is not None and len(result) == number_of_docs_to_return
+
+    # Drop DB with case sensitive collation for test.
+    conn.execute(text("use master"))
+    conn.execute(text(_DROP_COLLATION_DB_QUERY))
+    conn.close()

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -48,7 +48,7 @@ select object_id from sys.tables where name = '%s'
 and schema_name(schema_id) = '%s'"""
 
 
-FILTERING_TEST_CASES = [
+FILTERING_TEST_CASES: List[Any] = [
     filters
     for filterList in [
         TYPE_1_FILTERING_TEST_CASES,

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -605,15 +605,15 @@ def test_invalid_filters(
         store.similarity_search("meow", k=5, filter=invalid_filter)
 
 
+# We need to mock this so that actual connection is not attempted
+# after mocking _provide_token.
+@mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
-@mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
-)
 def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_is_used(
-    create_table: Mock,
     provide_token: Mock,
+    dialect_initialize: Mock,
 ) -> None:
     """Test that if a valid entra_id connection string is passed in
     to SQLServer_VectorStore object, entra id authentication is used
@@ -635,15 +635,15 @@ def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_i
     provide_token.assert_called()
 
 
-@mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
-)
+# We need to mock this so that actual connection is not attempted
+# after mocking _provide_token.
+@mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
 def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_used(
     provide_token: Mock,
-    create_table: Mock,
+    dialect_initialize: Mock,
 ) -> None:
     """Test that if a connection string is provided to SQLServer_VectorStore object,
     and connection string has username and password, entra id authentication is not
@@ -664,15 +664,15 @@ def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_us
     provide_token.assert_not_called()
 
 
+# We need to mock this so that actual connection is not attempted
+# after mocking _provide_token.
+@mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
-@mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
-)
 def test_that_connection_string_with_trusted_connection_yes_does_not_use_entra_id_auth(
-    create_table: Mock,
     provide_token: Mock,
+    dialect_initialize: Mock,
 ) -> None:
     """Test that if a connection string is provided to SQLServer_VectorStore object,
     and connection string has `trusted_connection` set to `yes`, entra id

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -317,7 +317,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     ]
     result = store.add_texts(texts, metadatas)
 
-    result = store.delete([])
+    result = store.delete(None)
     # Should return False, since empty list of ids given
     if not result:
         pass

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -557,7 +557,7 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     assert "_CS" in collation_query_result.collation_name
 
     store.add_texts(texts)
-    store._distance_strategy = DistanceStrategy.DOT
+    store.distance_strategy = DistanceStrategy.DOT
 
     # Call to similarity_search function should not error out.
     number_of_docs_to_return = 2

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -342,7 +342,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
         {"id": 600, "source": "newspaper page", "length": 44},
         {"id": 300, "source": "random texts", "length": 16},
     ]
-    result = store.add_texts(texts, metadatas)
+    store.add_texts(texts, metadatas)
 
     result = store.delete(None)
     # Should return False, since empty list of ids given

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -12,6 +12,7 @@ from sqlalchemy import create_engine, text
 
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores.sqlserver import (
+    DistanceStrategy,
     SQLServer_VectorStore,
 )
 from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
@@ -52,6 +53,17 @@ _COLLATION_DB_NAME = "LangChainCollationTest"
 _TABLE_NAME = "langchain_vector_store_tests"
 _TABLE_DOES_NOT_EXIST = "Table %s.%s does not exist."
 EMBEDDING_LENGTH = 1536
+
+# Query Strings
+#
+_CREATE_COLLATION_DB_QUERY = (
+    f"create database {_COLLATION_DB_NAME} collate SQL_Latin1_General_CP1_CS_AS;"
+)
+_COLLATION_QUERY = "select name, collation_name from sys.databases where name = N'%s';"
+_DROP_COLLATION_DB_QUERY = f"drop database {_COLLATION_DB_NAME}"
+_SYS_TABLE_QUERY = """
+select object_id from sys.tables where name = '%s'
+and schema_name(schema_id) = '%s'"""
 
 # Query Strings
 #
@@ -629,7 +641,54 @@ def test_invalid_filters(
     """Verify that invalid filters raise an error."""
     with pytest.raises(ValueError):
         store._create_filter_clause(invalid_filter)
+    
 
+def test_that_case_sensitivity_does_not_affect_distance_strategy(
+    texts: List[str],
+) -> None:
+    """Test that when distance strategy is set on a case sensitive DB,
+    a call to similarity search does not fail."""
+    connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
+
+    conn = create_engine(connection_string_to_master).connect()
+    conn.rollback()
+
+    if conn.connection.dbapi_connection is not None:
+        conn.connection.dbapi_connection.autocommit = True
+
+    conn.execute(text(_CREATE_COLLATION_DB_QUERY))
+    conn.execute(text(f"use {_COLLATION_DB_NAME}"))
+
+    store = SQLServer_VectorStore(
+        connection=conn,
+        connection_string=connection_string_to_master,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_length=EMBEDDING_LENGTH,
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
+    collation_query_result = (
+        conn.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
+    )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
+
+    assert (
+        collation_query_result is not None
+    ), "No collation data returned from the database."
+    # Confirm DB is case sensitive
+    assert "_CS" in collation_query_result.collation_name
+
+    store.add_texts(texts)
+    store._distance_strategy = DistanceStrategy.DOT
+
+    # Call to similarity_search function should not error out.
+    number_of_docs_to_return = 2
+    result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
+    assert result is not None and len(result) == number_of_docs_to_return
+
+    # Drop DB with case sensitive collation for test.
+    conn.execute(text("use master"))
+    conn.execute(text(_DROP_COLLATION_DB_QUERY))
+    conn.close()
 
 def test_sqlserver_with_no_metadata_filters(store: SQLServer_VectorStore) -> None:
     store.add_texts(filter_texts, None, filter_ids)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -1,11 +1,7 @@
 """Test SQLServer_VectorStore functionality."""
 
 import os
-<<<<<<< HEAD
 from typing import Any, Dict, Generator, List
-=======
-from typing import Generator, List
->>>>>>> sqlserver_vectorstore
 from unittest import mock
 from unittest.mock import Mock
 
@@ -573,7 +569,6 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     conn.execute(text(_DROP_COLLATION_DB_QUERY))
     conn.close()
 
-<<<<<<< HEAD
 def test_sqlserver_with_no_metadata_filters(store: SQLServer_VectorStore) -> None:
     store.add_texts(filter_texts, None, filter_ids)
     try:
@@ -627,8 +622,6 @@ def test_invalid_filters(
     with pytest.raises(ValueError):
         store.similarity_search("meow", k=5, filter=invalid_filter)
 
-=======
->>>>>>> sqlserver_vectorstore
 
 def test_that_entra_id_authentication_connection_is_successful(
     texts: List[str],

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -4,6 +4,7 @@ import os
 from typing import Any, Dict, Generator, List
 from unittest import mock
 from unittest.mock import Mock
+from typing import Any, Dict, Generator, List
 
 import pytest
 from langchain_core.documents import Document
@@ -11,7 +12,6 @@ from sqlalchemy import create_engine, text
 
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores.sqlserver import (
-    DistanceStrategy,
     SQLServer_VectorStore,
 )
 from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
@@ -509,52 +509,126 @@ def test_that_similarity_search_returns_results_with_scores_sorted_in_ascending_
     assert doc_with_score == sorted(doc_with_score, key=lambda x: x[1])
 
 
-def test_that_case_sensitivity_does_not_affect_distance_strategy(
-    texts: List[str],
+# def test_that_case_sensitivity_does_not_affect_distance_strategy(
+#     store: SQLServer_VectorStore,
+#     texts: List[str],
+# ) -> None:
+#     """Test that when distance strategy is set on a case sensitive DB,
+#     a call to similarity search does not fail."""
+
+#     connection = create_engine(_CONNECTION_STRING).connect()
+#     collation_query_result = (
+#         connection.execute(text(_COLLATION_QUERY % (_DATABASE_NAME))).fetchone()
+#     )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
+#     connection.close()
+
+#     assert (
+#         collation_query_result is not None
+#     ), "No collation data returned from the database."
+#     # Confirm DB is case sensitive
+#     assert "_CS" in collation_query_result.collation_name
+
+#     store.add_texts(texts)
+#     store._distance_strategy = DistanceStrategy.DOT
+
+#     # Call to similarity_search function should not error out.
+#     number_of_docs_to_return = 2
+#     result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
+#     assert result is not None and len(result) == number_of_docs_to_return
+
+
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_1_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_1(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
 ) -> None:
-    """Test that when distance strategy is set on a case sensitive DB,
-    a call to similarity search does not fail."""
-    connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
 
-    conn = create_engine(connection_string_to_master).connect()
-    conn.rollback()
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
 
-    if conn.connection.dbapi_connection is not None:
-        conn.connection.dbapi_connection.autocommit = True
 
-    conn.execute(text(_CREATE_COLLATION_DB_QUERY))
-    conn.execute(text(f"use {_COLLATION_DB_NAME}"))
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_2_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_2(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
+) -> None:
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
 
-    store = SQLServer_VectorStore(
-        connection=conn,
-        connection_string=connection_string_to_master,
-        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
-        embedding_length=EMBEDDING_LENGTH,
-        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
-        table_name=_TABLE_NAME,
-    )
-    collation_query_result = (
-        conn.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
-    )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
 
-    assert (
-        collation_query_result is not None
-    ), "No collation data returned from the database."
-    # Confirm DB is case sensitive
-    assert "_CS" in collation_query_result.collation_name
 
-    store.add_texts(texts)
-    store.distance_strategy = DistanceStrategy.DOT
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_3_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_3(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
+) -> None:
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
 
-    # Call to similarity_search function should not error out.
-    number_of_docs_to_return = 2
-    result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
-    assert result is not None and len(result) == number_of_docs_to_return
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
 
-    # Drop DB with case sensitive collation for test.
-    conn.execute(text("use master"))
-    conn.execute(text(_DROP_COLLATION_DB_QUERY))
-    conn.close()
+
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_4_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_4(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
+) -> None:
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
+
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
+
+
+@pytest.mark.parametrize("test_filter, expected_ids", TYPE_5_FILTERING_TEST_CASES)
+def test_sqlserver_with_with_metadata_filters_5(
+    store: SQLServer_VectorStore,
+    test_filter: Dict[str, Any],
+    expected_ids: List[int],
+) -> None:
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
+
+    docs = store.similarity_search("meow", k=5, filter=test_filter)
+    store.delete(["1", "2", "3"])
+
+    returned_ids = [doc.metadata["id"] for doc in docs]
+    assert sorted(returned_ids) == sorted(expected_ids), test_filter
+
+
+@pytest.mark.parametrize(
+    "invalid_filter",
+    [
+        ["hello"],
+        {
+            "id": 2,
+            "$name": "foo",
+        },
+        {"$or": {}},
+        {"$and": {}},
+        {"$between": {}},
+        {"$eq": {}},
+    ],
+)
+def test_invalid_filters(
+    store: SQLServer_VectorStore, invalid_filter: Dict[str, Any]
+) -> None:
+    """Verify that invalid filters raise an error."""
+    with pytest.raises(ValueError):
+        store._create_filter_clause(invalid_filter)
 
 
 def test_sqlserver_with_no_metadata_filters(store: SQLServer_VectorStore) -> None:

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -560,8 +560,8 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
 def test_sqlserver_with_no_metadata_filters(store: SQLServer_VectorStore) -> None:
     store.add_texts(filter_texts, None, filter_ids)
     try:
-        test_filter = {"id": 1}
-        expected_ids = []
+        test_filter: Dict[str, Any] = {"id": 1}
+        expected_ids: List[int] = []
         docs = store.similarity_search("meow", k=5, filter=test_filter)
         returned_ids = [doc.metadata["id"] for doc in docs]
         assert sorted(returned_ids) == sorted(expected_ids), test_filter

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -523,7 +523,7 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     assert "_CS" in collation_query_result.collation_name
 
     store.add_texts(texts)
-    store._distance_strategy = DistanceStrategy.DOT
+    store.distance_strategy = DistanceStrategy.DOT
 
     # Call to similarity_search function should not error out.
     number_of_docs_to_return = 2

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -521,32 +521,52 @@ def test_that_similarity_search_returns_results_with_scores_sorted_in_ascending_
     assert doc_with_score == sorted(doc_with_score, key=lambda x: x[1])
 
 
-# def test_that_case_sensitivity_does_not_affect_distance_strategy(
-#     store: SQLServer_VectorStore,
-#     texts: List[str],
-# ) -> None:
-#     """Test that when distance strategy is set on a case sensitive DB,
-#     a call to similarity search does not fail."""
+def test_that_case_sensitivity_does_not_affect_distance_strategy(
+    texts: List[str],
+) -> None:
+    """Test that when distance strategy is set on a case sensitive DB,
+    a call to similarity search does not fail."""
+    connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
 
-#     connection = create_engine(_CONNECTION_STRING).connect()
-#     collation_query_result = (
-#         connection.execute(text(_COLLATION_QUERY % (_DATABASE_NAME))).fetchone()
-#     )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
-#     connection.close()
+    conn = create_engine(connection_string_to_master).connect()
+    conn.rollback()
 
-#     assert (
-#         collation_query_result is not None
-#     ), "No collation data returned from the database."
-#     # Confirm DB is case sensitive
-#     assert "_CS" in collation_query_result.collation_name
+    if conn.connection.dbapi_connection is not None:
+        conn.connection.dbapi_connection.autocommit = True
 
-#     store.add_texts(texts)
-#     store._distance_strategy = DistanceStrategy.DOT
+    conn.execute(text(_CREATE_COLLATION_DB_QUERY))
+    conn.execute(text(f"use {_COLLATION_DB_NAME}"))
 
-#     # Call to similarity_search function should not error out.
-#     number_of_docs_to_return = 2
-#     result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
-#     assert result is not None and len(result) == number_of_docs_to_return
+    store = SQLServer_VectorStore(
+        connection=conn,
+        connection_string=connection_string_to_master,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_length=EMBEDDING_LENGTH,
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
+    collation_query_result = (
+        conn.execute(text(_COLLATION_QUERY % (_COLLATION_DB_NAME))).fetchone()
+    )  # Sample return value: ('LangChainVectors', 'SQL_Latin1_General_CP1_CS_AS')
+
+    assert (
+        collation_query_result is not None
+    ), "No collation data returned from the database."
+    # Confirm DB is case sensitive
+    assert "_CS" in collation_query_result.collation_name
+
+    store.add_texts(texts)
+    store._distance_strategy = DistanceStrategy.DOT
+
+    # Call to similarity_search function should not error out.
+    number_of_docs_to_return = 2
+    result = store.similarity_search(query="Good review", k=number_of_docs_to_return)
+    assert result is not None and len(result) == number_of_docs_to_return
+
+    # Drop DB with case sensitive collation for test.
+    conn.execute(text("use master"))
+    conn.execute(text(_DROP_COLLATION_DB_QUERY))
+    conn.close()
 
 
 @pytest.mark.parametrize("test_filter, expected_ids", TYPE_1_FILTERING_TEST_CASES)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -612,8 +612,8 @@ def test_invalid_filters(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
 )
 def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_is_used(
-    provide_token: Mock,
     create_table: Mock,
+    provide_token: Mock,
 ) -> None:
     """Test that if a valid entra_id connection string is passed in
     to SQLServer_VectorStore object, entra id authentication is used

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -31,6 +31,9 @@ from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
     texts as filter_texts,
 )
 
+# Connection String values should be provided in the
+# environment running this test suite.
+#
 _CONNECTION_STRING = str(os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING"))
 _CONNECTION_STRING_WITH_UID_AND_PWD = str(
     os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING_WITH_UID")

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -65,19 +65,6 @@ select object_id from sys.tables where name = '%s'
 and schema_name(schema_id) = '%s'"""
 
 
-FILTERING_TEST_CASES = [
-    filters
-    for filterList in [
-        TYPE_1_FILTERING_TEST_CASES,
-        TYPE_2_FILTERING_TEST_CASES,
-        TYPE_3_FILTERING_TEST_CASES,
-        TYPE_4_FILTERING_TEST_CASES,
-        TYPE_5_FILTERING_TEST_CASES,
-    ]
-    for filters in filterList
-]
-
-
 # Combine all test cases into one list with additional debugging
 FILTERING_TEST_CASES: List[Any] = []
 for filterList in [

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -38,8 +38,11 @@ _CONNECTION_STRING_WITH_UID_AND_PWD = str(
 _CONNECTION_STRING_WITH_TRUSTED_CONNECTION = str(
     os.environ.get("TEST_AZURESQLSERVER_TRUSTED_CONNECTION")
 )
-_ENTRA_ID_CONNECTION_STRING = str(
-    os.environ.get("TEST_AZURESQLSERVER_ENTRA_ID_CONNECTION_STRING")
+_ENTRA_ID_CONNECTION_STRING_NO_PARAMS = str(
+    os.environ.get("TEST_ENTRA_ID_CONNECTION_STRING_NO_PARAMS")
+)
+_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO = str(
+    os.environ.get("TEST_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO")
 )
 _SCHEMA = "lc_test"
 _COLLATION_DB_NAME = "LangChainCollationTest"
@@ -605,6 +608,17 @@ def test_invalid_filters(
         store.similarity_search("meow", k=5, filter=invalid_filter)
 
 
+def test_that_entra_id_authentication_connection_is_successful(
+    texts: List[str],
+) -> None:
+    """Test that given a valid entra id auth string, connection to DB is successful."""
+    vector_store = connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_NO_PARAMS)
+    vector_store.add_texts(texts)
+
+    # drop vector_store
+    vector_store.drop()
+
+
 # We need to mock this so that actual connection is not attempted
 # after mocking _provide_token.
 @mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
@@ -619,19 +633,19 @@ def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_i
     to SQLServer_VectorStore object, entra id authentication is used
     and connection is successful."""
 
-    # Connection string does not contain username and password,
-    # and Trusted_connection is set to `no`.
-    # mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
-    # ?driver=ODBC+Driver+17+for+SQL+Server&Trusted_Connection=no"
-    SQLServer_VectorStore(
-        connection_string=_ENTRA_ID_CONNECTION_STRING,
-        embedding_length=EMBEDDING_LENGTH,
-        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
-        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
-        table_name=_TABLE_NAME,
-    )
-
+    # Connection string is of the form below.
+    # "mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
+    # ?driver=ODBC+Driver+17+for+SQL+Server"
+    connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_NO_PARAMS)
     # _provide_token is called only during Entra ID authentication.
+    provide_token.assert_called()
+
+    # reset the mock so that it can be reused.
+    provide_token.reset_mock()
+
+    # "mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
+    # ?driver=ODBC+Driver+17+for+SQL+Server&Trusted_Connection=no"
+    connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO)
     provide_token.assert_called()
 
 
@@ -652,13 +666,7 @@ def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_us
     # Connection string contains username and password,
     # mssql+pyodbc://username:password@lc-test.database.windows.net,1433/lcvectorstore
     # ?driver=ODBC+Driver+17+for+SQL+Server"
-    SQLServer_VectorStore(
-        connection_string=_CONNECTION_STRING_WITH_UID_AND_PWD,
-        embedding_length=EMBEDDING_LENGTH,
-        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
-        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
-        table_name=_TABLE_NAME,
-    )
+    connect_to_vector_store(_CONNECTION_STRING_WITH_UID_AND_PWD)
 
     # _provide_token is called only during Entra ID authentication.
     provide_token.assert_not_called()
@@ -678,17 +686,20 @@ def test_that_connection_string_with_trusted_connection_yes_does_not_use_entra_i
     and connection string has `trusted_connection` set to `yes`, entra id
     authentication is not used and connection is successful."""
 
-    # Connection string does not contain username and password,
-    # but has `trusted_connection=yes`
+    # Connection string is of the form below.
     # mssql+pyodbc://@lc-test.database.windows.net,1433/lcvectorstore
     # ?driver=ODBC+Driver+17+for+SQL+Server&trusted_connection=yes"
-    SQLServer_VectorStore(
-        connection_string=_CONNECTION_STRING_WITH_TRUSTED_CONNECTION,
+    connect_to_vector_store(_CONNECTION_STRING_WITH_TRUSTED_CONNECTION)
+
+    # _provide_token is called only during Entra ID authentication.
+    provide_token.assert_not_called()
+
+
+def connect_to_vector_store(conn_string: str) -> SQLServer_VectorStore:
+    return SQLServer_VectorStore(
+        connection_string=conn_string,
         embedding_length=EMBEDDING_LENGTH,
         # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
         embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
         table_name=_TABLE_NAME,
     )
-
-    # _provide_token is called only during Entra ID authentication.
-    provide_token.assert_not_called()

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -47,16 +47,18 @@ _SYS_TABLE_QUERY = """
 select object_id from sys.tables where name = '%s'
 and schema_name(schema_id) = '%s'"""
 
-# Query Strings
-#
-_CREATE_COLLATION_DB_QUERY = (
-    f"create database {_COLLATION_DB_NAME} collate SQL_Latin1_General_CP1_CS_AS;"
-)
-_COLLATION_QUERY = "select name, collation_name from sys.databases where name = N'%s';"
-_DROP_COLLATION_DB_QUERY = f"drop database {_COLLATION_DB_NAME}"
-_SYS_TABLE_QUERY = """
-select object_id from sys.tables where name = '%s'
-and schema_name(schema_id) = '%s'"""
+
+FILTERING_TEST_CASES = [
+    filters
+    for filterList in [
+        TYPE_1_FILTERING_TEST_CASES,
+        TYPE_2_FILTERING_TEST_CASES,
+        TYPE_3_FILTERING_TEST_CASES,
+        TYPE_4_FILTERING_TEST_CASES,
+        TYPE_5_FILTERING_TEST_CASES,
+    ]
+    for filters in filterList
+]
 
 
 @pytest.fixture
@@ -536,8 +538,8 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     conn.close()
 
 
-@pytest.mark.parametrize("test_filter, expected_ids", TYPE_1_FILTERING_TEST_CASES)
-def test_sqlserver_with_with_metadata_filters_1(
+@pytest.mark.parametrize("test_filter, expected_ids", FILTERING_TEST_CASES)
+def test_sqlserver_with_metadata_filters(
     store: SQLServer_VectorStore,
     test_filter: Dict[str, Any],
     expected_ids: List[int],
@@ -546,64 +548,6 @@ def test_sqlserver_with_with_metadata_filters_1(
 
     docs = store.similarity_search("meow", k=5, filter=test_filter)
     store.delete(["1", "2", "3"])
-    returned_ids = [doc.metadata["id"] for doc in docs]
-    assert sorted(returned_ids) == sorted(expected_ids), test_filter
-
-
-@pytest.mark.parametrize("test_filter, expected_ids", TYPE_2_FILTERING_TEST_CASES)
-def test_sqlserver_with_with_metadata_filters_2(
-    store: SQLServer_VectorStore,
-    test_filter: Dict[str, Any],
-    expected_ids: List[int],
-) -> None:
-    store.add_texts(filter_texts, filter_metadatas, filter_ids)
-
-    docs = store.similarity_search("meow", k=5, filter=test_filter)
-    store.delete(["1", "2", "3"])
-    returned_ids = [doc.metadata["id"] for doc in docs]
-    assert sorted(returned_ids) == sorted(expected_ids), test_filter
-
-
-@pytest.mark.parametrize("test_filter, expected_ids", TYPE_3_FILTERING_TEST_CASES)
-def test_sqlserver_with_with_metadata_filters_3(
-    store: SQLServer_VectorStore,
-    test_filter: Dict[str, Any],
-    expected_ids: List[int],
-) -> None:
-    store.add_texts(filter_texts, filter_metadatas, filter_ids)
-
-    docs = store.similarity_search("meow", k=5, filter=test_filter)
-    store.delete(["1", "2", "3"])
-    returned_ids = [doc.metadata["id"] for doc in docs]
-    assert sorted(returned_ids) == sorted(expected_ids), test_filter
-
-
-@pytest.mark.parametrize("test_filter, expected_ids", TYPE_4_FILTERING_TEST_CASES)
-def test_sqlserver_with_with_metadata_filters_4(
-    store: SQLServer_VectorStore,
-    test_filter: Dict[str, Any],
-    expected_ids: List[int],
-) -> None:
-    store.add_texts(filter_texts, filter_metadatas, filter_ids)
-
-    docs = store.similarity_search("meow", k=5, filter=test_filter)
-    store.delete(["1", "2", "3"])
-
-    returned_ids = [doc.metadata["id"] for doc in docs]
-    assert sorted(returned_ids) == sorted(expected_ids), test_filter
-
-
-@pytest.mark.parametrize("test_filter, expected_ids", TYPE_5_FILTERING_TEST_CASES)
-def test_sqlserver_with_with_metadata_filters_5(
-    store: SQLServer_VectorStore,
-    test_filter: Dict[str, Any],
-    expected_ids: List[int],
-) -> None:
-    store.add_texts(filter_texts, filter_metadatas, filter_ids)
-
-    docs = store.similarity_search("meow", k=5, filter=test_filter)
-    store.delete(["1", "2", "3"])
-
     returned_ids = [doc.metadata["id"] for doc in docs]
     assert sorted(returned_ids) == sorted(expected_ids), test_filter
 
@@ -626,5 +570,7 @@ def test_invalid_filters(
     store: SQLServer_VectorStore, invalid_filter: Dict[str, Any]
 ) -> None:
     """Verify that invalid filters raise an error."""
+    store.add_texts(filter_texts, filter_metadatas, filter_ids)
+    store.delete(["1", "2", "3"])
     with pytest.raises(ValueError):
-        store._create_filter_clause(invalid_filter)
+        store.similarity_search("meow", k=5, filter=invalid_filter)


### PR DESCRIPTION
## Why make this change?
This PR contains implementation for hybrid search.

## Why is hybrid search needed?
Hybrid search enhances user customization by allowing the use of specific metadata filters during similarity searches. Users can get results filtered out as per the filter requests sent.

## What Filters are supported?

The vectorstore supports a set of filters that can be applied against the metadata fields of the documents.

\$eq | Equality (==)
\$ne | Inequality (!=)
\$lt | Less than (<)
\$lte | Less than or equal (<=)
\$gt | Greater than (>)
\$gte | Greater than or equal (>=)
\$in | Special Cased (in)
\$nin | Special Cased (not in)
\$between | Special Cased (between)
\$like | Text (like)
\$ilike | Text (case-insensitive like)
\$and | Logical (and)
\$or | Logical (or)


## What are some sample filters?

`filter={
        "$and": [
            {"id": {"$in": [1, 5, 2, 9]}},
            {"location": {"$in": ["pond", "market"]}},
        ]
    }`

`filter={"id": {"$in": [1, 5, 2, 9]}, "location": {"$in": ["pond", "market"]}}`

`filter={"id": {"$in": [1, 5, 2, 9]}}`

**_Note:_** If you provide a dict with multiple fields, but no operators, the top level will be interpreted as a logical AND filter

## What is this change?
This PR contains the following implementations / changes:

```    
def _create_filter_clause(self, filters: dict) -> None:
        """Convert LangChain IR filter representation to matching SQLAlchemy clauses.

        At the top level, we still don't know if we're working with a field
        or an operator for the keys. After we've determined that we can
        call the appropriate logic to handle filter creation.

        Args:
            filters: Dictionary of filters to apply to the query.

        Returns:
            SQLAlchemy clause to apply to the query.
```
This functions creates an SQLAlchemy filter cluase based on the filter input given. It also has a helper function.

```
def _handle_field_filter(
        self,
        field: str,
        value: Any,
    ) -> SQLColumnExpression:
        """Create a filter for a specific field.

        Args:
            field: name of field
            value: value to filter
                If provided as is then this will be an equality filter
                If provided as a dictionary then this will be a filter, the key
                will be the operator and the value will be the value to filter by

        Returns:
            sqlalchemy expression
        """
```
This helper function handles the field filter conversion, where you have a field and respective filter for that field.

## How was this tested?
We have used the standard test cases provided in 
`C:\SQLTeamProjects\LangChainRepo\langchain\libs\community\tests\integration_tests\vectorstores\fixtures\filtering_test_cases.py`  for testing purposes. These tests cover a wide range of filter choices as below:

```
1. equality checks
2. String field
3. Boolean fields
4. And semantics for top level filtering
5. equality checks and other operators like $ne, $gt, $gte, $lt, $lte, $not
6. gt, gte, lt, lte relying on lexicographical ordering
7. float column
8. AND and OR operators
9. special operators like $in, $nin, $between
10. special operators like $like, $ilike

Also, a few filters was used to check possible failure cases.
```
<img width="1648" alt="image" src="https://github.com/user-attachments/assets/cd6f5b2c-a663-4217-b474-68417918d7e4">

NB: These tests will be moved in a later PR to the integration test folder and proper unit tests will be created also.


### Note

A small unit test fix for delete_api was merged into this PR. It is a one liner change, in line # 347 of test_sqlserver.py, where the delete api is called with None.
