### PR TITLE
Enable Entra ID Authentication

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,8 +1,16 @@
 from enum import Enum
-from typing import Any, Iterable, List, MutableMapping, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Iterable,
+    List,
+    MutableMapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 from urllib.parse import urlparse
 
-from azure.identity import DefaultAzureCredential
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VST, VectorStore
@@ -525,6 +533,8 @@ class SQLServer_VectorStore(VectorStore):
     ) -> None:
         """Get token for SQLServer connection from token URL,
         and use the token to connect to the database."""
+        from azure.identity import DefaultAzureCredential
+
         credential = DefaultAzureCredential()
 
         # Remove Trusted_Connection param that SQLAlchemy adds to

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Iterable, List, MutableMapping, Optional, Tuple, Type, Union
 from urllib.parse import urlparse
 
 from azure.identity import DefaultAzureCredential
@@ -9,6 +9,7 @@ from langchain_core.vectorstores import VST, VectorStore
 from sqlalchemy import (
     CheckConstraint,
     Column,
+    Dialect,
     Uuid,
     asc,
     bindparam,
@@ -21,6 +22,7 @@ from sqlalchemy.dialects.mssql import JSON, NVARCHAR, VARBINARY, VARCHAR
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DBAPIError, ProgrammingError
 from sqlalchemy.orm import Session
+from sqlalchemy.pool import ConnectionPoolEntry
 
 try:
     from sqlalchemy.orm import declarative_base
@@ -514,7 +516,13 @@ class SQLServer_VectorStore(VectorStore):
             logging.error(e.__cause__)
         return result
 
-    def _provide_token(self, dialect, conn_rec, cargs, cparams) -> None:
+    def _provide_token(
+        self,
+        dialect: Dialect,
+        conn_rec: Optional[ConnectionPoolEntry],
+        cargs: List[str],
+        cparams: MutableMapping[str, Any],
+    ) -> None:
         """Get token for SQLServer connection from token URL,
         and use the token to connect to the database."""
         credential = DefaultAzureCredential()

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -102,6 +102,8 @@ class SQLServer_VectorStore(VectorStore):
             connection_string: SQLServer connection string.
                 If the connection string does not contain a username & password
                 or `Trusted_Connection=yes`, Entra ID authentication is used.
+                Sample connection string format:
+                "mssql+pyodbc://username:password@servername/dbname?other_params"
             db_schema: The schema in which the vector store will be created.
                 This schema must exist and the user must have permissions to the schema.
             distance_strategy: The distance strategy to use for comparing embeddings.
@@ -131,6 +133,13 @@ class SQLServer_VectorStore(VectorStore):
         self._create_table_if_not_exists()
 
     def _can_connect_with_entra_id(self) -> bool:
+        """Check the components of the connection string to determine
+        if connection via Entra ID authentication is possible or not.
+
+        The connection string is of expected to be of the form:
+            "mssql+pyodbc://username:password@servername/dbname?other_params"
+        which gets parsed into -> <scheme>://<netloc>/<path>?<query>
+        """
         parsed_url = urlparse(self.connection_string)
 
         if parsed_url is None:

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Any, Iterable, List, Optional, Tuple, Type, Union
+from urllib.parse import urlparse
 
+from azure.identity import DefaultAzureCredential
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VST, VectorStore
@@ -11,6 +13,7 @@ from sqlalchemy import (
     asc,
     bindparam,
     create_engine,
+    event,
     label,
     text,
 )
@@ -26,6 +29,7 @@ except ImportError:
 
 import json
 import logging
+import struct
 import uuid
 
 
@@ -41,6 +45,7 @@ class DistanceStrategy(str, Enum):
 
 # String Constants
 #
+AZURE_TOKEN_URL = "https://database.windows.net/.default"  # Token URL for Azure DBs.
 DISTANCE = "distance"
 DEFAULT_DISTANCE_STRATEGY = DistanceStrategy.COSINE
 DISTANCE_STRATEGY = "distancestrategy"
@@ -48,8 +53,10 @@ EMBEDDING = "embedding"
 EMBEDDING_LENGTH = "embedding_length"
 EMBEDDING_VALUES = "embeddingvalues"
 EMPTY_IDS_ERROR_MESSAGE = "Empty list of ids provided"
+EXTRA_PARAMS = ";Trusted_Connection=Yes"
 INVALID_IDS_ERROR_MESSAGE = "Invalid list of ids provided"
 INVALID_INPUT_ERROR_MESSAGE = "Input is not valid."
+SQL_COPT_SS_ACCESS_TOKEN = 1256  # Connection option defined by microsoft in msodbcsql.h
 
 # Query Constants
 #
@@ -83,6 +90,8 @@ class SQLServer_VectorStore(VectorStore):
         Args:
             connection: Optional SQLServer connection.
             connection_string: SQLServer connection string.
+                If the connection string does not contain a username & password
+                or `Trusted_Connection=yes`, Entra ID authentication is used.
             db_schema: The schema in which the vector store will be created.
                 This schema must exist and the user must have permissions to the schema.
             distance_strategy: The distance strategy to use for comparing embeddings.
@@ -111,7 +120,28 @@ class SQLServer_VectorStore(VectorStore):
         self._embedding_store = self._get_embedding_store(table_name, db_schema)
         self._create_table_if_not_exists()
 
+    def _can_connect_with_entra_id(self) -> bool:
+        parsed_url = urlparse(self.connection_string)
+
+        if parsed_url is None:
+            logging.error("Unable to parse connection string.")
+            return False
+
+        if (parsed_url.username and parsed_url.password) or (
+            "trusted_connection=yes" in parsed_url.query.lower()
+        ):
+            return False
+
+        return True
+
     def _create_engine(self) -> Engine:
+        if self._can_connect_with_entra_id():
+            # Use Entra ID auth. Listen for a connection event
+            # when `_create_engine` function from this class is called.
+            #
+            event.listen(Engine, "do_connect", self._provide_token)
+            logging.info("Using Entra ID Authentication.")
+
         return create_engine(url=self.connection_string)
 
     def _create_table_if_not_exists(self) -> None:
@@ -483,3 +513,21 @@ class SQLServer_VectorStore(VectorStore):
         except DBAPIError as e:
             logging.error(e.__cause__)
         return result
+
+    def _provide_token(self, dialect, conn_rec, cargs, cparams) -> None:
+        """Get token for SQLServer connection from token URL,
+        and use the token to connect to the database."""
+        credential = DefaultAzureCredential()
+
+        # Remove Trusted_Connection param that SQLAlchemy adds to
+        # the connection string by default.
+        cargs[0] = cargs[0].replace(EXTRA_PARAMS, str())
+
+        # Create credential token
+        token_bytes = credential.get_token(AZURE_TOKEN_URL).token.encode("utf-16-le")
+        token_struct = struct.pack(
+            f"<I{len(token_bytes)}s", len(token_bytes), token_bytes
+        )
+
+        # Apply credential token to keyword argument
+        cparams["attrs_before"] = {SQL_COPT_SS_ACCESS_TOKEN: token_struct}

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -526,8 +526,8 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
 )
 def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_is_used(
-    provide_token: Mock,
     create_table: Mock,
+    provide_token: Mock,
 ) -> None:
     """Test that if a valid entra_id connection string is passed in
     to SQLServer_VectorStore object, entra id authentication is used

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -22,8 +22,11 @@ _CONNECTION_STRING_WITH_UID_AND_PWD = str(
 _CONNECTION_STRING_WITH_TRUSTED_CONNECTION = str(
     os.environ.get("TEST_AZURESQLSERVER_TRUSTED_CONNECTION")
 )
-_ENTRA_ID_CONNECTION_STRING = str(
-    os.environ.get("TEST_AZURESQLSERVER_ENTRA_ID_CONNECTION_STRING")
+_ENTRA_ID_CONNECTION_STRING_NO_PARAMS = str(
+    os.environ.get("TEST_ENTRA_ID_CONNECTION_STRING_NO_PARAMS")
+)
+_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO = str(
+    os.environ.get("TEST_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO")
 )
 _SCHEMA = "lc_test"
 _COLLATION_DB_NAME = "LangChainCollationTest"
@@ -519,6 +522,17 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     conn.close()
 
 
+def test_that_entra_id_authentication_connection_is_successful(
+    texts: List[str],
+) -> None:
+    """Test that given a valid entra id auth string, connection to DB is successful."""
+    vector_store = connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_NO_PARAMS)
+    vector_store.add_texts(texts)
+
+    # drop vector_store
+    vector_store.drop()
+
+
 # We need to mock this so that actual connection is not attempted
 # after mocking _provide_token.
 @mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
@@ -533,19 +547,19 @@ def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_i
     to SQLServer_VectorStore object, entra id authentication is used
     and connection is successful."""
 
-    # Connection string does not contain username and password,
-    # and Trusted_connection is set to `no`.
-    # mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
-    # ?driver=ODBC+Driver+17+for+SQL+Server&Trusted_Connection=no"
-    SQLServer_VectorStore(
-        connection_string=_ENTRA_ID_CONNECTION_STRING,
-        embedding_length=EMBEDDING_LENGTH,
-        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
-        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
-        table_name=_TABLE_NAME,
-    )
-
+    # Connection string is of the form below.
+    # "mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
+    # ?driver=ODBC+Driver+17+for+SQL+Server"
+    connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_NO_PARAMS)
     # _provide_token is called only during Entra ID authentication.
+    provide_token.assert_called()
+
+    # reset the mock so that it can be reused.
+    provide_token.reset_mock()
+
+    # "mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
+    # ?driver=ODBC+Driver+17+for+SQL+Server&Trusted_Connection=no"
+    connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO)
     provide_token.assert_called()
 
 
@@ -566,13 +580,7 @@ def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_us
     # Connection string contains username and password,
     # mssql+pyodbc://username:password@lc-test.database.windows.net,1433/lcvectorstore
     # ?driver=ODBC+Driver+17+for+SQL+Server"
-    SQLServer_VectorStore(
-        connection_string=_CONNECTION_STRING_WITH_UID_AND_PWD,
-        embedding_length=EMBEDDING_LENGTH,
-        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
-        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
-        table_name=_TABLE_NAME,
-    )
+    connect_to_vector_store(_CONNECTION_STRING_WITH_UID_AND_PWD)
 
     # _provide_token is called only during Entra ID authentication.
     provide_token.assert_not_called()
@@ -592,17 +600,20 @@ def test_that_connection_string_with_trusted_connection_yes_does_not_use_entra_i
     and connection string has `trusted_connection` set to `yes`, entra id
     authentication is not used and connection is successful."""
 
-    # Connection string does not contain username and password,
-    # but has `trusted_connection=yes`
+    # Connection string is of the form below.
     # mssql+pyodbc://@lc-test.database.windows.net,1433/lcvectorstore
     # ?driver=ODBC+Driver+17+for+SQL+Server&trusted_connection=yes"
-    SQLServer_VectorStore(
-        connection_string=_CONNECTION_STRING_WITH_TRUSTED_CONNECTION,
+    connect_to_vector_store(_CONNECTION_STRING_WITH_TRUSTED_CONNECTION)
+
+    # _provide_token is called only during Entra ID authentication.
+    provide_token.assert_not_called()
+
+
+def connect_to_vector_store(conn_string: str) -> SQLServer_VectorStore:
+    return SQLServer_VectorStore(
+        connection_string=conn_string,
         embedding_length=EMBEDDING_LENGTH,
         # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
         embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
         table_name=_TABLE_NAME,
     )
-
-    # _provide_token is called only during Entra ID authentication.
-    provide_token.assert_not_called()

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -15,6 +15,9 @@ from langchain_community.vectorstores.sqlserver import (
     SQLServer_VectorStore,
 )
 
+# Connection String values should be provided in the
+# environment running this test suite.
+#
 _CONNECTION_STRING = str(os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING"))
 _CONNECTION_STRING_WITH_UID_AND_PWD = str(
     os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING_WITH_UID")

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -519,15 +519,15 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     conn.close()
 
 
+# We need to mock this so that actual connection is not attempted
+# after mocking _provide_token.
+@mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
-@mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
-)
 def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_is_used(
-    create_table: Mock,
     provide_token: Mock,
+    dialect_initialize: Mock,
 ) -> None:
     """Test that if a valid entra_id connection string is passed in
     to SQLServer_VectorStore object, entra id authentication is used
@@ -549,15 +549,15 @@ def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_i
     provide_token.assert_called()
 
 
-@mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
-)
+# We need to mock this so that actual connection is not attempted
+# after mocking _provide_token.
+@mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
 def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_used(
     provide_token: Mock,
-    create_table: Mock,
+    dialect_initialize: Mock,
 ) -> None:
     """Test that if a connection string is provided to SQLServer_VectorStore object,
     and connection string has username and password, entra id authentication is not
@@ -578,15 +578,15 @@ def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_us
     provide_token.assert_not_called()
 
 
+# We need to mock this so that actual connection is not attempted
+# after mocking _provide_token.
+@mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
-@mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
-)
 def test_that_connection_string_with_trusted_connection_yes_does_not_use_entra_id_auth(
-    create_table: Mock,
     provide_token: Mock,
+    dialect_initialize: Mock,
 ) -> None:
     """Test that if a connection string is provided to SQLServer_VectorStore object,
     and connection string has `trusted_connection` set to `yes`, entra id

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -2,6 +2,8 @@
 
 import os
 from typing import Generator, List
+from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 from langchain_core.documents import Document
@@ -14,6 +16,15 @@ from langchain_community.vectorstores.sqlserver import (
 )
 
 _CONNECTION_STRING = str(os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING"))
+_CONNECTION_STRING_WITH_UID_AND_PWD = str(
+    os.environ.get("TEST_AZURESQLSERVER_CONNECTION_STRING_WITH_UID")
+)
+_CONNECTION_STRING_WITH_TRUSTED_CONNECTION = str(
+    os.environ.get("TEST_AZURESQLSERVER_TRUSTED_CONNECTION")
+)
+_ENTRA_ID_CONNECTION_STRING = str(
+    os.environ.get("TEST_AZURESQLSERVER_ENTRA_ID_CONNECTION_STRING")
+)
 _SCHEMA = "lc_test"
 _COLLATION_DB_NAME = "LangChainCollationTest"
 _TABLE_NAME = "langchain_vector_store_tests"
@@ -506,3 +517,92 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     conn.execute(text("use master"))
     conn.execute(text(_DROP_COLLATION_DB_QUERY))
     conn.close()
+
+
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
+)
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
+)
+def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_is_used(
+    provide_token: Mock,
+    create_table: Mock,
+) -> None:
+    """Test that if a valid entra_id connection string is passed in
+    to SQLServer_VectorStore object, entra id authentication is used
+    and connection is successful."""
+
+    # Connection string does not contain username and password,
+    # and Trusted_connection is set to `no`.
+    # mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
+    # ?driver=ODBC+Driver+17+for+SQL+Server&Trusted_Connection=no"
+    SQLServer_VectorStore(
+        connection_string=_ENTRA_ID_CONNECTION_STRING,
+        embedding_length=EMBEDDING_LENGTH,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
+
+    # _provide_token is called only during Entra ID authentication.
+    provide_token.assert_called()
+
+
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
+)
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
+)
+def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_used(
+    provide_token: Mock,
+    create_table: Mock,
+) -> None:
+    """Test that if a connection string is provided to SQLServer_VectorStore object,
+    and connection string has username and password, entra id authentication is not
+    used and connection is successful."""
+
+    # Connection string contains username and password,
+    # mssql+pyodbc://username:password@lc-test.database.windows.net,1433/lcvectorstore
+    # ?driver=ODBC+Driver+17+for+SQL+Server"
+    SQLServer_VectorStore(
+        connection_string=_CONNECTION_STRING_WITH_UID_AND_PWD,
+        embedding_length=EMBEDDING_LENGTH,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
+
+    # _provide_token is called only during Entra ID authentication.
+    provide_token.assert_not_called()
+
+
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
+)
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_table_if_not_exists"
+)
+def test_that_connection_string_with_trusted_connection_yes_does_not_use_entra_id_auth(
+    create_table: Mock,
+    provide_token: Mock,
+) -> None:
+    """Test that if a connection string is provided to SQLServer_VectorStore object,
+    and connection string has `trusted_connection` set to `yes`, entra id
+    authentication is not used and connection is successful."""
+
+    # Connection string does not contain username and password,
+    # but has `trusted_connection=yes`
+    # mssql+pyodbc://@lc-test.database.windows.net,1433/lcvectorstore
+    # ?driver=ODBC+Driver+17+for+SQL+Server&trusted_connection=yes"
+    SQLServer_VectorStore(
+        connection_string=_CONNECTION_STRING_WITH_TRUSTED_CONNECTION,
+        embedding_length=EMBEDDING_LENGTH,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
+
+    # _provide_token is called only during Entra ID authentication.
+    provide_token.assert_not_called()


### PR DESCRIPTION
## Why make this change?
`SQLServer_VectorStore` currently allows authentication using username and password or with `Integrated Security`. We want to enable authentication via Entra ID.
## What is this change?
This change enables SQL Server authentication via Entra ID. With this new implementation, users can authenticate to SQL Server using:
- Username & Password
- Trusted Connection (Integrated Security)
- Entra ID

In order to use Entra ID authentication, we need to first get an access token for SQL Server connection from the token URL `https://database.windows.net/.default`, and use the token to connect to the database.

To do this, the following options cannot be present in the connection string provided:
- username
- password
- trusted_connection=yes (Integrated Security).

Entra ID authentication will work if `trusted_connection` = no

The specific authentication method used by `SQLServer_VectorStore` is determined by the content of the connection string provided.

- mssql+pyodbc://username:password@servername/dbname?driver=ODBC+Driver+17+for+SQL+Server --> No Entra ID
- mssql+pyodbc://@servername/dbname?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes --> No Entra ID
- mssql+pyodbc://@servername/dbname?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=no --> Entra ID
- mssql+pyodbc://@servername/dbname?driver=ODBC+Driver+17+for+SQL+Server --> Entra ID

We do this by checking the components of the connection string using `urlparse` function from `urllib`.
The connection string expected to be of the form:
`mssql+pyodbc://username:password@servername/dbname?other_params`
gets parsed into -> `<scheme>://<netloc>/<path>?<query>`

## Tests
Additional tests have been added to verify that the appropriate connection auth is used based on the content of the connection string.

NB:  It is assumed that connection string values are already available in the environment where test is being run. If it hasn't been provided, these values should be set before running the test suite.

In the new tests, we mock `_provide_token` function, a function that gets called when Entra ID authentication is in use. This function gets the access token that is used to connect to the DB.

If Entra ID authentication is expected, then `_provide_token` function must be called. If otherwise, then `_provide_token` should not be called.

![image](https://github.com/user-attachments/assets/3a0bf844-f3d4-481e-8d26-2ef6f0662fee)
