### PR TITLE
Improve Table Schema

### DIFF
--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -228,26 +228,14 @@ def test_that_add_text_fails_if_text_embedding_length_is_not_equal_to_embedding_
 
 def test_sqlserver_delete_text_by_id_valid_ids_provided(
     store: SQLServer_VectorStore,
+    texts: List[str],
+    metadatas: List[dict],
 ) -> None:
     """Test that delete API deletes texts by id."""
-    texts = [
-        "Good review",
-        "new books",
-        "table",
-        "Sunglasses are a form of protective eyewear.",
-        "It's a new year.",
-    ]
 
-    metadatas = [
-        {"id": 100, "source": "book review", "length": 11},
-        {"id": 200, "source": "random texts", "length": 9},
-        {"id": 200, "source": "household list", "length": 5},
-        {"id": 600, "source": "newspaper page", "length": 44},
-        {"id": 300, "source": "random texts", "length": 16},
-    ]
     store.add_texts(texts, metadatas)
 
-    result = store.delete(["100", "200", "600"])
+    result = store.delete(["1", "2", "5"])
     # Should return true since valid ids are given
     if result:
         pass
@@ -255,26 +243,14 @@ def test_sqlserver_delete_text_by_id_valid_ids_provided(
 
 def test_sqlserver_delete_text_by_id_valid_id_and_invalid_ids_provided(
     store: SQLServer_VectorStore,
+    texts: List[str],
+    metadatas: List[dict],
 ) -> None:
     """Test that delete API deletes texts by id."""
-    texts = [
-        "Good review",
-        "new books",
-        "table",
-        "Sunglasses are a form of protective eyewear.",
-        "It's a new year.",
-    ]
 
-    metadatas = [
-        {"id": 100, "source": "book review", "length": 11},
-        {"id": 200, "source": "random texts", "length": 9},
-        {"id": 200, "source": "household list", "length": 5},
-        {"id": 600, "source": "newspaper page", "length": 44},
-        {"id": 300, "source": "random texts", "length": 16},
-    ]
     store.add_texts(texts, metadatas)
 
-    result = store.delete(["100", "200", "600", "900"])
+    result = store.delete(["1", "2", "6", "9"])
     # Should return true since valid ids are given
     if result:
         pass
@@ -282,23 +258,11 @@ def test_sqlserver_delete_text_by_id_valid_id_and_invalid_ids_provided(
 
 def test_sqlserver_delete_text_by_id_invalid_ids_provided(
     store: SQLServer_VectorStore,
+    texts: List[str],
+    metadatas: List[dict],
 ) -> None:
     """Test that delete API deletes texts by id."""
-    texts = [
-        "Good review",
-        "new books",
-        "table",
-        "Sunglasses are a form of protective eyewear.",
-        "It's a new year.",
-    ]
 
-    metadatas = [
-        {"id": 100, "source": "book review", "length": 11},
-        {"id": 200, "source": "random texts", "length": 9},
-        {"id": 200, "source": "household list", "length": 5},
-        {"id": 600, "source": "newspaper page", "length": 44},
-        {"id": 300, "source": "random texts", "length": 16},
-    ]
     store.add_texts(texts, metadatas)
 
     result = store.delete(["100000"])
@@ -309,23 +273,11 @@ def test_sqlserver_delete_text_by_id_invalid_ids_provided(
 
 def test_sqlserver_delete_text_by_id_no_ids_provided(
     store: SQLServer_VectorStore,
+    texts: List[str],
+    metadatas: List[dict],
 ) -> None:
     """Test that delete API deletes texts by id."""
-    texts = [
-        "Good review",
-        "new books",
-        "table",
-        "Sunglasses are a form of protective eyewear.",
-        "It's a new year.",
-    ]
 
-    metadatas = [
-        {"id": 100, "source": "book review", "length": 11},
-        {"id": 200, "source": "random texts", "length": 9},
-        {"id": 200, "source": "household list", "length": 5},
-        {"id": 600, "source": "newspaper page", "length": 44},
-        {"id": 300, "source": "random texts", "length": 16},
-    ]
     result = store.add_texts(texts, metadatas)
 
     # Should return False, since empty list of ids given

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -471,13 +471,34 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
     conn.close()
 
 
+def test_that_rows_with_duplicate_custom_id_cannot_be_entered(
+    store: SQLServer_VectorStore,
+    texts: List[str],
+) -> None:
+    """Test that if a row is specified with existing ID in the table,
+    `add_texts` fails."""
+    metadatas = [
+        {"id": 1, "summary": "Good Quality Dog Food"},
+        {"id": 2, "summary": "Nasty No flavor"},
+        {"id": 2, "summary": "stale product"},
+        {"id": 4, "summary": "Great value and convenient ramen"},
+        {"id": 5, "summary": "Great for the kids!"},
+    ]
+    with pytest.raises(Exception):
+        store.add_texts(texts, metadatas)
+
+
 # We need to mock this so that actual connection is not attempted
 # after mocking _provide_token.
 @mock.patch("sqlalchemy.dialects.mssql.dialect.initialize")
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._prepare_json_data_type"
+)
 def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_is_used(
+    prep_data_type: Mock,
     provide_token: Mock,
     dialect_initialize: Mock,
 ) -> None:
@@ -507,7 +528,11 @@ def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_i
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._prepare_json_data_type"
+)
 def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_used(
+    prep_data_type: Mock,
     provide_token: Mock,
     dialect_initialize: Mock,
 ) -> None:
@@ -536,7 +561,11 @@ def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_us
 @mock.patch(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
+@mock.patch(
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._prepare_json_data_type"
+)
 def test_that_connection_string_with_trusted_connection_yes_does_not_use_entra_id_auth(
+    prep_data_type: Mock,
     provide_token: Mock,
     dialect_initialize: Mock,
 ) -> None:


### PR DESCRIPTION
## Why make this change?
The purpose of this change is to improve the current table schema. Doing this will help improve table performance and storage used.
An example of the inefficiencies is using `VARCHAR(max)` to store `custom_id` for the table created in `SQLServer_VectorStore`.
## What is this change?
- `custom_id` uses `varchar(1000)` instead of `varchar(max)`
- primary key `id` is non-clustered
- unique non-clustered index created on `custom_id`. This ensures that data with same `custom_id` cannot be entered into the table.
- `content_metadata` column uses `json` data type if the data type is available on the server, we determine this by checking if `type id` 244 is available in `sys.types`. In a scenario where `json` data type is not available, the data type of this column defaults to the value provided by sqlalchemy which is `NVARCHAR(max)`.

The primary key is made non-clustered because we use random values (uniqueidentifier).

If we were to have a clustered index, this would have been best suited for the custom_id column. However, there doesn't seem to be a need for this since the ultimate goal of this table is to do a semantic search on it. We don't need the entries to be sorted in any order, hence, the reason we have a non-clustered index on `custom_id`.

#### Sample generated create table query
```
CREATE TABLE  langchain_store_connection_test_v1 (
        id UNIQUEIDENTIFIER NOT NULL,
        custom_id VARCHAR(1000) NULL,
        content_metadata json NULL,
        content NVARCHAR(max) NOT NULL,
        embeddings VARBINARY(8000) NOT NULL CHECK (ISVECTOR(embeddings, 384) = 1),
        PRIMARY KEY NONCLUSTERED (id)
)

CREATE UNIQUE NONCLUSTERED INDEX idx_custom_id ON langchain_store_connection_test_v1 (custom_id)
```
![image](https://github.com/user-attachments/assets/8d08e73e-d88d-42f2-8f77-2121ee68cfd2)

## Tests
Additional test has been added to check that adding a row with pre-existing `custom_id` value in the table will error out.
![image](https://github.com/user-attachments/assets/879b391e-4e87-4938-ae50-9caf5aee4285)

![image](https://github.com/user-attachments/assets/b480c5e3-885f-4849-ac50-54f3643c8934)