### PR TITLE
Support Vector Type & Remove VARBINARY support

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -102,20 +102,20 @@ class DistanceStrategy(str, Enum):
 class VectorType(UserDefinedType):
     cache_ok = True
 
-    def __init__(self, length: int):
+    def __init__(self, length: int) -> None:
         self.length = length
 
-    def get_col_spec(self, **kw: Any):
+    def get_col_spec(self, **kw: Any) -> str:
         return "vector(%s)" % self.length
 
-    def bind_processor(self, dialect: Any):
-        def process(value: Any):
+    def bind_processor(self, dialect: Any) -> Any:
+        def process(value: Any) -> Any:
             return value
 
         return process
 
-    def result_processor(self, dialect: Any, coltype: Any):
-        def process(value: Any):
+    def result_processor(self, dialect: Any, coltype: Any) -> Any:
+        def process(value: Any) -> Any:
             return value
 
         return process

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -794,6 +794,10 @@ class SQLServer_VectorStore(VectorStore):
                             ),
                         )
                     )
+                    # `embedding_store` is created in a dictionary format instead
+                    # of using the embedding_store object from this class.
+                    # This enables the use of `insert().values()` which can only
+                    # take a dict and not a custom object.
                     embedding_store = {
                         "custom_id": custom_id,
                         "content_metadata": metadata,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -105,17 +105,17 @@ class VectorType(UserDefinedType):
     def __init__(self, length: int):
         self.length = length
 
-    def get_col_spec(self, **kw):
+    def get_col_spec(self, **kw: Any):
         return "vector(%s)" % self.length
 
-    def bind_processor(self, dialect):
-        def process(value):
+    def bind_processor(self, dialect: Any):
+        def process(value: Any):
             return value
 
         return process
 
-    def result_processor(self, dialect, coltype):
-        def process(value):
+    def result_processor(self, dialect: Any, coltype: Any):
+        def process(value: Any):
             return value
 
         return process

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -17,7 +17,6 @@ from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VST, VectorStore
 from sqlalchemy import (
-    CheckConstraint,
     Column,
     ColumnElement,
     Dialect,
@@ -37,7 +36,7 @@ from sqlalchemy import (
     select,
     text,
 )
-from sqlalchemy.dialects.mssql import JSON, NVARCHAR, VARBINARY, VARCHAR
+from sqlalchemy.dialects.mssql import JSON, NVARCHAR, VARCHAR
 from sqlalchemy.dialects.mssql.base import MSTypeCompiler
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DBAPIError, ProgrammingError
@@ -144,11 +143,11 @@ SQL_COPT_SS_ACCESS_TOKEN = 1256  # Connection option defined by microsoft in mso
 
 # Query Constants
 #
-EMBEDDING_LENGTH_CONSTRAINT = f"ISVECTOR(embeddings, :{EMBEDDING_LENGTH}) = 1"
+JSON_TO_VECTOR_QUERY = f"cast (:{EMBEDDING_VALUES} as vector(:{EMBEDDING_LENGTH}))"
 SERVER_JSON_CHECK_QUERY = "select name from sys.types where system_type_id = 244"
-VECTOR_TYPE_CHECK_QUERY = (
-    "select name from sys.types where system_type_id = 165 and user_type_id = 255"
-)
+VECTOR_DISTANCE_QUERY = f"""
+VECTOR_DISTANCE(:{DISTANCE_STRATEGY},
+cast (:{EMBEDDING} as vector(:{EMBEDDING_LENGTH})), embeddings)"""
 
 
 class SQLServer_VectorStore(VectorStore):
@@ -204,9 +203,7 @@ class SQLServer_VectorStore(VectorStore):
         self._bind: Union[Connection, Engine] = (
             connection if connection else self._create_engine()
         )
-        # We assume the DB does not have access to VECTOR data type by default.
-        self._has_vector_data_type = False
-        self._check_data_type()
+        self._prepare_json_data_type()
         self._embedding_store = self._get_embedding_store(self.table_name, self.schema)
         self._create_table_if_not_exists()
 
@@ -271,49 +268,28 @@ class SQLServer_VectorStore(VectorStore):
             )  # column for user defined ids.
             content_metadata = Column(JSON, nullable=True)
             content = Column(NVARCHAR, nullable=False)  # defaults to NVARCHAR(MAX)
-            embeddings = (
-                # Use vector data type with embedding length. We also do not want to
-                # set constraint on this column since VECTOR will handle that.
-                Column(VectorType(self._embedding_length), nullable=False)
-                if self._has_vector_data_type
-                # Add check constraint to embeddings column
-                # this will ensure only vectors of the same size
-                # are allowed in the vector store.
-                else Column(
-                    VARBINARY(8000),
-                    CheckConstraint(
-                        text(EMBEDDING_LENGTH_CONSTRAINT).bindparams(
-                            bindparam(EMBEDDING_LENGTH, self._embedding_length)
-                        )
-                    ),
-                    nullable=False,
-                )
-            )
+            embeddings = Column(VectorType(self._embedding_length), nullable=False)
 
         return EmbeddingStore
 
-    def _check_data_type(self) -> None:
-        """Check if the server has the JSON and VECTOR data type available.
-        For each available data type, we use our corresponding type instead
-        of NVARCHAR(max) and VARBINARY respectively. If the type is not
-        available, this defaults to NVARCHAR(max) and VARBINARY respectively
-        as specified by sqlalchemy."""
+    def _prepare_json_data_type(self) -> None:
+        """Check if the server has the JSON data type available. If it does,
+        we compile JSON data type as JSON instead of NVARCHAR(max) used by
+        sqlalchemy. If it doesn't, this defaults to NVARCHAR(max) as specified
+        by sqlalchemy."""
         try:
             with Session(self._bind) as session:
-                json_data_type = session.scalar(text(SERVER_JSON_CHECK_QUERY))
-                vector_data_type = session.scalar(text(VECTOR_TYPE_CHECK_QUERY))
+                result = session.scalar(text(SERVER_JSON_CHECK_QUERY))
                 session.close()
 
-                if json_data_type is not None:
+                if result is not None:
 
                     @compiles(JSON, "mssql")
                     def compile_json(
                         element: JSON, compiler: MSTypeCompiler, **kw: Any
                     ) -> str:
                         # return JSON when JSON data type is specified in this class.
-                        return json_data_type  # json data type name in sql server
-
-                self._has_vector_data_type = vector_data_type is not None
+                        return result  # json data type name in sql server
 
         except ProgrammingError as e:
             logging.error(f"Unable to get data types.\n {e.__cause__}\n")
@@ -478,14 +454,6 @@ class SQLServer_VectorStore(VectorStore):
                 if filter_clauses is not None:
                     filter_by.append(filter_clauses)
 
-                if self._has_vector_data_type:
-                    VECTOR_DISTANCE_QUERY = f"""
-VECTOR_DISTANCE(:{DISTANCE_STRATEGY},
-cast (:{EMBEDDING} as vector({self._embedding_length})), embeddings)"""
-                else:
-                    VECTOR_DISTANCE_QUERY = f"""
-VECTOR_DISTANCE(:{DISTANCE_STRATEGY},
-JSON_ARRAY_TO_VECTOR(:{EMBEDDING}), embeddings)"""
                 results = (
                     session.query(
                         self._embedding_store,
@@ -500,6 +468,11 @@ JSON_ARRAY_TO_VECTOR(:{EMBEDDING}), embeddings)"""
                                 bindparam(
                                     EMBEDDING,
                                     json.dumps(embedding),
+                                    literal_execute=True,
+                                ),
+                                bindparam(
+                                    EMBEDDING_LENGTH,
+                                    self._embedding_length,
                                     literal_execute=True,
                                 ),
                             ),
@@ -800,9 +773,33 @@ JSON_ARRAY_TO_VECTOR(:{EMBEDDING}), embeddings)"""
 
                     # Construct text, embedding, metadata as EmbeddingStore model
                     # to be inserted into the table.
-                    embedding_store = self._create_embedding_store_for_insert(
-                        custom_id, embedding, metadata, query
+                    sqlquery = select(
+                        text(JSON_TO_VECTOR_QUERY).bindparams(
+                            bindparam(
+                                EMBEDDING_VALUES,
+                                json.dumps(embedding),
+                                literal_execute=True,
+                                # when unique is set to true, the name of the key
+                                # for each bindparameter is made unique, to avoid
+                                # using the wrong bound parameter during compile.
+                                # This is especially needed since we're creating
+                                # and storing multiple queries to be bulk inserted
+                                # later on.
+                                unique=True,
+                            ),
+                            bindparam(
+                                EMBEDDING_LENGTH,
+                                self._embedding_length,
+                                literal_execute=True,
+                            ),
+                        )
                     )
+                    embedding_store = {
+                        "custom_id": custom_id,
+                        "content_metadata": metadata,
+                        "content": query,
+                        "embeddings": sqlquery,
+                    }
                     documents.append(embedding_store)
                 session.execute(insert(self._embedding_store).values(documents))
                 session.commit()
@@ -813,53 +810,6 @@ JSON_ARRAY_TO_VECTOR(:{EMBEDDING}), embeddings)"""
             logging.error("Metadata must be a list of dictionaries.")
             raise
         return ids
-
-    def _create_embedding_store_for_insert(
-        self, custom_id: str, embedding: List[float], metadata: List[dict], query: str
-    ) -> dict:
-        """Create a dictionary with keys equal to attributes of embeddingstore object.
-        The values associated with the key `embeddings` depends on the availability
-        of the VECTOR data type.
-        """
-        if self._has_vector_data_type:
-            sqlquery = select(
-                text(
-                    f"cast (:{EMBEDDING_VALUES} as vector({self._embedding_length}))"
-                ).bindparams(
-                    bindparam(
-                        EMBEDDING_VALUES,
-                        json.dumps(embedding),
-                        literal_execute=True,
-                        unique=True,
-                    ),
-                )
-            )
-
-        else:
-            sqlquery = select(
-                text(f"JSON_ARRAY_TO_VECTOR (:{EMBEDDING_VALUES})").bindparams(
-                    bindparam(
-                        EMBEDDING_VALUES,
-                        json.dumps(embedding),
-                        # render the value of the parameter into SQL statement
-                        # at statement execution time
-                        literal_execute=True,
-                        # Ensures that the bindparameter key for the select statement
-                        # generated is unique. This allows us generate multiple select
-                        # statements with their individual embedding parameters.
-                        unique=True,
-                    )
-                )
-            )
-
-        # Result from the sqlquery will be inserted into the embeddings
-        # column during insertion run.
-        return {
-            "custom_id": custom_id,
-            "content_metadata": metadata,
-            "content": query,
-            "embeddings": sqlquery,
-        }
 
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
         """Delete embeddings in the vectorstore by the ids.
@@ -881,7 +831,7 @@ JSON_ARRAY_TO_VECTOR(:{EMBEDDING}), embeddings)"""
             logging.info(INVALID_IDS_ERROR_MESSAGE)
             return False
 
-        logging.info(result, " rows affected.")
+        logging.info(f"{result} rows affected.")
         return True
 
     def _delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> int:

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -47,6 +47,9 @@ _ENTRA_ID_CONNECTION_STRING_NO_PARAMS = str(
 _ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO = str(
     os.environ.get("TEST_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO")
 )
+_MASTER_DATABASE_CONNECTION_STRING = str(
+    os.environ.get("TEST_AZURESQLSERVER_MASTER_CONNECTION_STRING")
+)
 _SCHEMA = "lc_test"
 _COLLATION_DB_NAME = "LangChainCollationTest"
 _TABLE_NAME = "langchain_vector_store_tests"
@@ -466,7 +469,7 @@ def test_that_case_sensitivity_does_not_affect_distance_strategy(
 ) -> None:
     """Test that when distance strategy is set on a case sensitive DB,
     a call to similarity search does not fail."""
-    connection_string_to_master = "mssql+pyodbc://@localhost/master?driver=ODBC+Driver+17+for+SQL+Server&Trusted_connection=yes"
+    connection_string_to_master = _MASTER_DATABASE_CONNECTION_STRING
 
     conn = create_engine(connection_string_to_master).connect()
     conn.rollback()

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -1,5 +1,6 @@
 """Test SQLServer_VectorStore functionality."""
 
+import json
 import os
 from typing import Any, Dict, Generator, List
 from unittest import mock
@@ -7,7 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 from langchain_core.documents import Document
-from sqlalchemy import create_engine, text
+from sqlalchemy import bindparam, create_engine, text
 
 from langchain_community.embeddings import FakeEmbeddings
 from langchain_community.vectorstores.sqlserver import (
@@ -584,11 +585,39 @@ def test_that_entra_id_authentication_connection_is_successful(
     texts: List[str],
 ) -> None:
     """Test that given a valid entra id auth string, connection to DB is successful."""
-    vector_store = connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_NO_PARAMS)
+    # vector_store = connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_NO_PARAMS)
+    vector_store = SQLServer_VectorStore(
+        connection_string=_ENTRA_ID_CONNECTION_STRING_NO_PARAMS,
+        embedding_length=EMBEDDING_LENGTH,
+        # FakeEmbeddings returns embeddings of the same size as `embedding_length`.
+        embedding_function=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        table_name=_TABLE_NAME,
+    )
     vector_store.add_texts(texts)
 
     # drop vector_store
     vector_store.drop()
+
+
+def test_that_embedding_from_native_vector_type_is_same_with_non_native_type() -> None:
+    """Test that value returned by a call to `JSON_ARRAY_TO_VECTOR` is same as
+    that returned by `cast as vector`."""
+    embedding = FakeEmbeddings(size=EMBEDDING_LENGTH).embed_query("good books.")
+
+    non_native_vector_query = text(
+        "select JSON_ARRAY_TO_VECTOR (:embedding)"
+    ).bindparams(bindparam("embedding", json.dumps(embedding), literal_execute=True))
+    native_vector_query = text(
+        f"select cast (:embedding as vector({EMBEDDING_LENGTH}))"
+    ).bindparams(bindparam("embedding", json.dumps(embedding), literal_execute=True))
+
+    engine = create_engine(_CONNECTION_STRING)
+    non_native_vector_result = (
+        engine.connect().execute(non_native_vector_query).scalar()
+    )
+    native_vector_result = engine.connect().execute(native_vector_query).scalar()
+
+    assert non_native_vector_result == native_vector_result
 
 
 # We need to mock this so that actual connection is not attempted
@@ -598,7 +627,7 @@ def test_that_entra_id_authentication_connection_is_successful(
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
 @mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._prepare_json_data_type"
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._check_data_type"
 )
 def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_is_used(
     prep_data_type: Mock,
@@ -612,17 +641,20 @@ def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_i
     # Connection string is of the form below.
     # "mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
     # ?driver=ODBC+Driver+17+for+SQL+Server"
-    connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_NO_PARAMS)
+    store = connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_NO_PARAMS)
     # _provide_token is called only during Entra ID authentication.
     provide_token.assert_called()
+
+    store.drop()
 
     # reset the mock so that it can be reused.
     provide_token.reset_mock()
 
     # "mssql+pyodbc://lc-test.database.windows.net,1433/lcvectorstore
     # ?driver=ODBC+Driver+17+for+SQL+Server&Trusted_Connection=no"
-    connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO)
+    store = connect_to_vector_store(_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO)
     provide_token.assert_called()
+    store.drop()
 
 
 # We need to mock this so that actual connection is not attempted
@@ -632,7 +664,7 @@ def test_that_given_a_valid_entra_id_connection_string_entra_id_authentication_i
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
 @mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._prepare_json_data_type"
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._check_data_type"
 )
 def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_used(
     prep_data_type: Mock,
@@ -646,10 +678,12 @@ def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_us
     # Connection string contains username and password,
     # mssql+pyodbc://username:password@lc-test.database.windows.net,1433/lcvectorstore
     # ?driver=ODBC+Driver+17+for+SQL+Server"
-    connect_to_vector_store(_CONNECTION_STRING_WITH_UID_AND_PWD)
+    store = connect_to_vector_store(_CONNECTION_STRING_WITH_UID_AND_PWD)
 
     # _provide_token is called only during Entra ID authentication.
     provide_token.assert_not_called()
+
+    store.drop()
 
 
 # We need to mock this so that actual connection is not attempted
@@ -659,7 +693,7 @@ def test_that_given_a_connection_string_with_uid_and_pwd_entra_id_auth_is_not_us
     "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._provide_token"
 )
 @mock.patch(
-    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._prepare_json_data_type"
+    "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._check_data_type"
 )
 def test_that_connection_string_with_trusted_connection_yes_does_not_use_entra_id_auth(
     prep_data_type: Mock,
@@ -673,10 +707,11 @@ def test_that_connection_string_with_trusted_connection_yes_does_not_use_entra_i
     # Connection string is of the form below.
     # mssql+pyodbc://@lc-test.database.windows.net,1433/lcvectorstore
     # ?driver=ODBC+Driver+17+for+SQL+Server&trusted_connection=yes"
-    connect_to_vector_store(_CONNECTION_STRING_WITH_TRUSTED_CONNECTION)
+    store = connect_to_vector_store(_CONNECTION_STRING_WITH_TRUSTED_CONNECTION)
 
     # _provide_token is called only during Entra ID authentication.
     provide_token.assert_not_called()
+    store.drop()
 
 
 def connect_to_vector_store(conn_string: str) -> SQLServer_VectorStore:


### PR DESCRIPTION
## Why make this change?
The purpose of this change is to add support of `vector` data type in our vectorstore implementation. With this support added, we no longer need to use the `VARBINARY` implementation for vectors, hence, we remove the support for `VARBINARY` data type.

## What is this change?
- Remove `VARBINARY` implementation - This change removes every reference related to the VARBINARY implementation. This include:
    - column definition with `VARBINARY` data type.
    - queries made referencing `JSON_TO_ARRAY` & `IS_VECTOR` functions.
- Define UserDefined type for `vector` data type ---> This step is needed because `sqlalchemy` does not have a pre-defined `vector` data type. We define a data type that when used will take in a length and when compiled in `sqlalchemy` returns a value like `vector(384)` where `384` is the specified length.
- Use functions related to `vector` data type to convert an embedding to vector and perform similarity search.
- Another change made in this PR is how we convert an embedding to vector and store it. Previously, for every embedding we have, we first run a query in SQL Server to convert the embedding to a vector, store the result as part of an embeddingstore object and then run a bulk insert on the list of objects we have. Now, we store the values we want to insert in a dictionary format, and in this format, the `embeddings` column is used to store a query (to convert `embedding` to `vector`) that will be run while we perform a bulk insert. This way, we perform the insertion with one connection, and we don't have to worry about how python & sqlalchemy handles the data type of the result of converting `embedding` to `vector`.
- `bulk_save_objects(documents)` is updated to `execute(insert(self._embedding_store).values(documents))`. Both functions do a bulk insert, however, the second option allows us to perform query runs during insertion.
- update event.listen() params -> The addition `once=True` ensures that the event function `_provide_token` is run only once.
- rename local variable `id` to `custom_id`. This is to ensure we don't have future clashes with pythons' in-built `id` function.
- Update logging info string concatenation which fails because we attempt to concatenate incompatible types.
- Ensure test cleanup by calling `drop` of created vectorstores.

## Tests
With these new updates, existing behavior is not expected to change. Therefore, the existing tests should be able to run and pass as is.
Test runs were successful.