### PR TITLE
Anushakolan/sqlvector unit tests 2

### DIFF
--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -1,0 +1,398 @@
+# Unit test class
+import json
+import os
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+from langchain_core.documents.base import Document
+
+from langchain_community.embeddings import FakeEmbeddings
+from langchain_community.vectorstores.sqlserver import (
+    DistanceStrategy,
+    SQLServer_VectorStore,
+)
+
+EMBEDDING_LENGTH = 1536
+_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO = str(
+    os.environ.get("TEST_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO")
+)
+
+
+def generalized_mock_factory():
+    mocks = {
+        "_create_engine": MagicMock(),
+        "_prepare_json_data_type": MagicMock(),
+        "_get_embedding_store": MagicMock(),
+        "_create_table_if_not_exists": MagicMock(),
+        "_can_connect_with_entra_id": MagicMock(),
+        "_provide_token": MagicMock(return_value=True),
+        "_handle_field_filter": MagicMock(),
+        "_docs_from_result": MagicMock(),
+        "_docs_and_scores_from_result": MagicMock(),
+        "_insert_embeddings": MagicMock(),
+        "delete": MagicMock(),
+        "_delete_texts_by_ids": MagicMock(),
+        "similarity_search": MagicMock(),
+        "similarity_search_by_vector": MagicMock(),
+        "similarity_search_with_score": MagicMock(),
+        "similarity_search_by_vector_with_score": MagicMock(),
+        "add_texts": MagicMock(),
+        "drop": MagicMock(),
+        "_create_filter_clause": MagicMock(),
+        "_search_store": MagicMock(),
+    }
+
+    with ExitStack() as stack:
+        for method, mock in mocks.items():
+            stack.enter_context(
+                patch(
+                    f"langchain_community.vectorstores.sqlserver.SQLServer_VectorStore.{method}",
+                    mock,
+                )
+            )
+
+        connection_string = _ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO
+        db_schema = "test_schema"
+        distance_strategy = DistanceStrategy.DOT
+        embedding_function = FakeEmbeddings(size=128)
+        embedding_length = 128
+        table_name = "test_table"
+
+        store = SQLServer_VectorStore(
+            connection_string=connection_string,
+            db_schema=db_schema,
+            distance_strategy=distance_strategy,
+            embedding_function=embedding_function,
+            embedding_length=embedding_length,
+            table_name=table_name,
+        )
+
+    return store, mocks
+
+
+def test_init():
+    # Arrange
+    store, mocks = generalized_mock_factory()
+
+    # Assert
+    assert store.connection_string == _ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO
+    assert store._distance_strategy == DistanceStrategy.DOT
+    assert store.embedding_function == FakeEmbeddings(size=128)
+    assert store._embedding_length == 128
+    assert store.schema == "test_schema"
+    assert store.table_name == "test_table"
+    mocks["_create_engine"].assert_called_once()
+    mocks["_prepare_json_data_type"].assert_called_once()
+    mocks["_get_embedding_store"].assert_called_once_with("test_table", "test_schema")
+    mocks["_create_table_if_not_exists"].assert_called_once()
+
+
+def test_can_connect_with_entra_id():
+    store, mocks = generalized_mock_factory()
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._can_connect_with_entra_id",
+        wraps=SQLServer_VectorStore._can_connect_with_entra_id,
+    ), patch(
+        "langchain_community.vectorstores.sqlserver.urlparse", wraps=MagicMock()
+    ) as mock_urlparse:
+        # case 1: parsed_url is None
+        mock_urlparse.return_value = None
+        result = store._can_connect_with_entra_id(store)
+        mock_urlparse.assert_called_once_with(store.connection_string)
+        assert result is False
+
+        mock_urlparse.reset_mock()
+
+        # case 2: parsed_url has username and password
+        url_value = {
+            "username": "username123",
+            "password": "password123",
+        }
+
+        json_string = json.dumps(url_value, indent=4)
+
+        parsed_json = json.loads(
+            json_string, object_hook=lambda d: SimpleNamespace(**d)
+        )
+
+        mock_urlparse.return_value = parsed_json
+
+        result = store._can_connect_with_entra_id(store)
+        mock_urlparse.assert_called_once_with(store.connection_string)
+        assert result is False
+
+        mock_urlparse.reset_mock()
+
+        # case 3: parsed_url has trusted_connection=yes
+        url_value = {
+            "username": None,
+            "password": None,
+            "query": "trusted_connection=yes",
+        }
+
+        json_string = json.dumps(url_value, indent=4)
+
+        parsed_json = json.loads(
+            json_string, object_hook=lambda d: SimpleNamespace(**d)
+        )
+        mock_urlparse.return_value = parsed_json
+
+        result = store._can_connect_with_entra_id(store)
+        mock_urlparse.assert_called_once_with(store.connection_string)
+        assert result is False
+
+        mock_urlparse.reset_mock()
+
+        # case 4: parsed_url does not have trusted_connection=yes,
+        #  no username and password
+        url_value = {
+            "username": None,
+            "password": None,
+            "query": "trusted_connection=no",
+        }
+
+        json_string = json.dumps(url_value, indent=4)
+
+        parsed_json = json.loads(
+            json_string, object_hook=lambda d: SimpleNamespace(**d)
+        )
+        mock_urlparse.return_value = parsed_json
+
+        result = store._can_connect_with_entra_id(store)
+        mock_urlparse.assert_called_once_with(store.connection_string)
+        assert result is True
+
+
+def test_create_engine():
+    # Arrange
+    store, mocks = generalized_mock_factory()
+    mocks["_can_connect_with_entra_id"].return_value = True
+
+    # Unpatch _create_engine to call the actual method
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
+        wraps=SQLServer_VectorStore._create_engine,
+    ), patch.object(
+        store, "_can_connect_with_entra_id", wraps=mocks["_can_connect_with_entra_id"]
+    ), patch.object(store, "_provide_token", wraps=mocks["_provide_token"]), patch(
+        "sqlalchemy.event.listen"
+    ) as mock_listen:
+        engine = store._create_engine(store)
+
+    mocks["_can_connect_with_entra_id"].assert_called_once()
+
+    if mocks["_can_connect_with_entra_id"].return_value:
+        specific_calls = [
+            call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
+        ]
+        assert len(specific_calls) == 1, f"""Expected 'do_connect' to be called once.
+          Called {len(specific_calls)} times."""
+        specific_calls[0].assert_called_once_with(
+            engine, "do_connect", store._provide_token, once=True
+        )
+
+    mock_listen.reset_mock()
+    mocks["_can_connect_with_entra_id"].reset_mock()
+
+    mocks["_can_connect_with_entra_id"].return_value = False
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
+        wraps=SQLServer_VectorStore._create_engine,
+    ), patch.object(
+        store, "_can_connect_with_entra_id", wraps=mocks["_can_connect_with_entra_id"]
+    ), patch.object(store, "_provide_token", wraps=mocks["_provide_token"]), patch(
+        "sqlalchemy.event.listen"
+    ) as mock_listen:
+        engine = store._create_engine(store)
+
+    mocks["_can_connect_with_entra_id"].assert_called_once()
+
+    specific_calls = [
+        call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
+    ]
+    assert (
+        len(specific_calls) == 0
+    ), f"Expected 'do_connect' to be called once. Called {len(specific_calls)} times."
+
+
+def test_similarity_search():
+    store, mocks = generalized_mock_factory()
+
+    query = "hi"
+    mock_responses = {"hello": [0.1, 0.2, 0.3], "hi": [0.01, 0.02, 0.03]}
+
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore.similarity_search",
+        wraps=SQLServer_VectorStore.similarity_search,
+    ), patch.object(
+        store, "similarity_search_by_vector", wraps=mocks["similarity_search_by_vector"]
+    ):
+        store.embedding_function = Mock()
+        store.embedding_function.embed_query = Mock()
+        store.embedding_function.embed_query.return_value = mock_responses[query]
+        store.similarity_search_by_vector.return_value = mock_responses
+
+        store.similarity_search(store, query)
+
+        store.similarity_search_by_vector.assert_called_once_with([0.01, 0.02, 0.03], 4)
+
+        store.similarity_search_by_vector.reset_mock()
+
+        query = "hello"
+        store.embedding_function.embed_query.reset_mock()
+        store.embedding_function.embed_query.return_value = mock_responses[query]
+
+        store.similarity_search(store, query, 7)
+
+        store.similarity_search_by_vector.assert_called_once_with([0.1, 0.2, 0.3], 7)
+
+
+def test_similarity_search_by_vector():
+    store, mocks = generalized_mock_factory()
+
+    with (
+        patch(
+            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore.similarity_search_by_vector",
+            wraps=SQLServer_VectorStore.similarity_search_by_vector,
+        ),
+        patch.object(
+            store,
+            "similarity_search_by_vector_with_score",
+            wraps=mocks["similarity_search_by_vector_with_score"],
+        ),
+        patch.object(store, "_docs_from_result", wraps=mocks["_docs_from_result"]),
+    ):
+        embeddings = [0.1, 0.2, 0.3]
+        mock_responses = {
+            tuple(["0.01", "0.02", "0.03"]): (
+                Document(
+                    page_content="""Got these on sale for roughly 25 cents per cup"""
+                ),
+                0.9588668232580106,
+            ),
+        }
+        expected_result = (
+            Document(page_content="Got these on sale for roughly 25 cents per cup"),
+            0.9588668232580106,
+        )
+
+        store.similarity_search_by_vector_with_score.return_value = mock_responses[
+            tuple(["0.01", "0.02", "0.03"])
+        ]
+        store._docs_from_result.return_value = expected_result
+
+        store.similarity_search_by_vector(store, embeddings)
+
+        store.similarity_search_by_vector_with_score.assert_called_once_with(
+            embeddings, 4
+        )
+        store._docs_from_result.assert_called_once_with(
+            mock_responses[tuple(["0.01", "0.02", "0.03"])]
+        )
+
+        store.similarity_search_by_vector_with_score.reset_mock()
+        store._docs_from_result.reset_mock()
+
+        store.similarity_search_by_vector(store, embeddings, 7)
+
+        store._docs_from_result.assert_called_once_with(
+            mock_responses[tuple(["0.01", "0.02", "0.03"])]
+        )
+        store.similarity_search_by_vector_with_score.assert_called_once_with(
+            [0.1, 0.2, 0.3], 7
+        )
+        store._docs_from_result.assert_called_once_with(
+            mock_responses[tuple(["0.01", "0.02", "0.03"])]
+        )
+
+
+def test_similarity_search_wih_score():
+    store, mocks = generalized_mock_factory()
+
+    query = "hi"
+    mock_responses = {"hello": [0.1, 0.2, 0.3], "hi": [0.01, 0.02, 0.03]}
+
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore.similarity_search_with_score",
+        wraps=SQLServer_VectorStore.similarity_search_with_score,
+    ), patch.object(
+        store,
+        "similarity_search_by_vector_with_score",
+        wraps=mocks["similarity_search_by_vector_with_score"],
+    ):
+        store.embedding_function = Mock()
+        store.embedding_function.embed_query = Mock()
+        store.embedding_function.embed_query.return_value = mock_responses[query]
+        store.similarity_search_by_vector_with_score.return_value = mock_responses
+
+        store.similarity_search_with_score(store, query)
+
+        store.similarity_search_by_vector_with_score.assert_called_once_with(
+            [0.01, 0.02, 0.03], 4
+        )
+
+        store.similarity_search_by_vector_with_score.reset_mock()
+
+        query = "hello"
+        store.embedding_function.embed_query.reset_mock()
+        store.embedding_function.embed_query.return_value = mock_responses[query]
+
+        store.similarity_search_with_score(store, query, 7)
+
+        store.similarity_search_by_vector_with_score.assert_called_once_with(
+            [0.1, 0.2, 0.3], 7
+        )
+
+
+def test_similarity_search_by_vector_with_score():
+    store, mocks = generalized_mock_factory()
+
+    with (
+        patch(
+            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore."
+            "similarity_search_by_vector_with_score",
+            wraps=SQLServer_VectorStore.similarity_search_by_vector_with_score,
+        ),
+        patch.object(store, "_search_store", wraps=mocks["_search_store"]),
+        patch.object(
+            store,
+            "_docs_and_scores_from_result",
+            wraps=mocks["_docs_and_scores_from_result"],
+        ),
+    ):
+        embeddings = tuple[0.01, 0.02, 0.03]
+
+        expected_search_result = """(<langchain_community.vectorstores.sqlserver.
+           SQLServer_VectorStore._get_embedding_store.<locals>.EmbeddingStore object
+             at 0x0000025EFFF84810>,
+                 0.9595672912317021)"""
+        expected_docs = (
+            Document(page_content="""Got these on sale for roughly 25 cents per cup"""),
+            0.9588668232580106,
+        )
+
+        store._search_store.return_value = expected_search_result
+        store._docs_and_scores_from_result.return_value = expected_docs
+
+        # case 1: k is not given
+        result = store.similarity_search_by_vector_with_score(store, embeddings)
+
+        store._search_store.assert_called_once_with(embeddings, 4)
+        store._docs_and_scores_from_result.assert_called_once_with(
+            expected_search_result
+        )
+        assert result == expected_docs
+
+        store.similarity_search_by_vector_with_score.reset_mock()
+        store._docs_and_scores_from_result.reset_mock()
+        store._search_store.reset_mock()
+
+        # case 2: k =7
+        result = store.similarity_search_by_vector_with_score(store, embeddings, 7)
+
+        store._search_store.assert_called_once_with(embeddings, 7)
+        store._docs_and_scores_from_result.assert_called_once_with(
+            expected_search_result
+        )
+        assert result == expected_docs

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -171,18 +171,26 @@ def test_create_engine() -> None:
     mocks["_can_connect_with_entra_id"].return_value = True
 
     # Unpatch _create_engine to call the actual method
-    with patch(
-        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
-        wraps=SQLServer_VectorStore._create_engine,
-    ), patch.object(
-        store, "_can_connect_with_entra_id", wraps=mocks["_can_connect_with_entra_id"]
-    ), patch.object(sqlalchemy, "create_engine", wraps=MagicMock()), patch.object(
-        store, "_provide_token", wraps=mocks["_provide_token"]
-    ), patch("sqlalchemy.event.listen") as mock_listen:
+    with (
+        patch(
+            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
+            wraps=SQLServer_VectorStore._create_engine,
+        ),
+        patch.object(
+            store,
+            "_can_connect_with_entra_id",
+            wraps=mocks["_can_connect_with_entra_id"],
+        ),
+        patch.object(store, "_provide_token", wraps=mocks["_provide_token"]),
+        patch("sqlalchemy.event.listen") as mock_listen,
+        patch.object(
+            sqlalchemy, "create_engine", wraps=MagicMock()
+        ) as mock_create_engine,
+    ):
         engine = store._create_engine(store)
 
     mocks["_can_connect_with_entra_id"].assert_called_once()
-
+    mock_create_engine.return_value = MagicMock()
     if mocks["_can_connect_with_entra_id"].return_value:
         specific_calls = [
             call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
@@ -197,18 +205,25 @@ def test_create_engine() -> None:
     mocks["_can_connect_with_entra_id"].reset_mock()
 
     mocks["_can_connect_with_entra_id"].return_value = False
-    with patch(
-        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
-        wraps=SQLServer_VectorStore._create_engine,
-    ), patch.object(
-        store, "_can_connect_with_entra_id", wraps=mocks["_can_connect_with_entra_id"]
-    ), patch.object(
-        sqlalchemy, 'create_engine', wraps=MagicMock()
-    ),patch.object(store, "_provide_token", wraps=mocks["_provide_token"]), patch(
-        "sqlalchemy.event.listen"
-    ) as mock_listen:
+    with (
+        patch(
+            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
+            wraps=SQLServer_VectorStore._create_engine,
+        ),
+        patch.object(
+            store,
+            "_can_connect_with_entra_id",
+            wraps=mocks["_can_connect_with_entra_id"],
+        ),
+        patch.object(
+            sqlalchemy, "create_engine", wraps=MagicMock
+        ) as mock_create_engine,
+        patch.object(store, "_provide_token", wraps=mocks["_provide_token"]),
+        patch("sqlalchemy.event.listen") as mock_listen,
+    ):
         engine = store._create_engine(store)
 
+    mock_create_engine.return_value = MagicMock()
     mocks["_can_connect_with_entra_id"].assert_called_once()
 
     specific_calls = [

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -12,6 +12,7 @@ from langchain_community.vectorstores.sqlserver import (
     DistanceStrategy,
     SQLServer_VectorStore,
 )
+import sqlalchemy
 
 EMBEDDING_LENGTH = 1536
 _ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO = str(
@@ -19,7 +20,7 @@ _ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO = str(
 )
 
 
-def generalized_mock_factory():
+def generalized_mock_factory() -> None:
     mocks = {
         "_create_engine": MagicMock(),
         "_prepare_json_data_type": MagicMock(),
@@ -88,7 +89,7 @@ def test_init():
     mocks["_create_table_if_not_exists"].assert_called_once()
 
 
-def test_can_connect_with_entra_id():
+def test_can_connect_with_entra_id() -> None:
     store, mocks = generalized_mock_factory()
     with patch(
         "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._can_connect_with_entra_id",
@@ -164,7 +165,7 @@ def test_can_connect_with_entra_id():
         assert result is True
 
 
-def test_create_engine():
+def test_create_engine() -> None:
     # Arrange
     store, mocks = generalized_mock_factory()
     mocks["_can_connect_with_entra_id"].return_value = True
@@ -175,9 +176,9 @@ def test_create_engine():
         wraps=SQLServer_VectorStore._create_engine,
     ), patch.object(
         store, "_can_connect_with_entra_id", wraps=mocks["_can_connect_with_entra_id"]
-    ), patch.object(store, "_provide_token", wraps=mocks["_provide_token"]), patch(
-        "sqlalchemy.event.listen"
-    ) as mock_listen:
+    ), patch.object(sqlalchemy, "create_engine", wraps=MagicMock), patch.object(
+        store, "_provide_token", wraps=mocks["_provide_token"]
+    ), patch("sqlalchemy.event.listen") as mock_listen:
         engine = store._create_engine(store)
 
     mocks["_can_connect_with_entra_id"].assert_called_once()
@@ -216,7 +217,7 @@ def test_create_engine():
     ), f"Expected 'do_connect' to be called once. Called {len(specific_calls)} times."
 
 
-def test_similarity_search():
+def test_similarity_search() -> None:
     store, mocks = generalized_mock_factory()
 
     query = "hi"
@@ -248,7 +249,7 @@ def test_similarity_search():
         store.similarity_search_by_vector.assert_called_once_with([0.1, 0.2, 0.3], 7)
 
 
-def test_similarity_search_by_vector():
+def test_similarity_search_by_vector() -> None:
     store, mocks = generalized_mock_factory()
 
     with (
@@ -307,7 +308,7 @@ def test_similarity_search_by_vector():
         )
 
 
-def test_similarity_search_wih_score():
+def test_similarity_search_wih_score() -> None:
     store, mocks = generalized_mock_factory()
 
     query = "hi"
@@ -345,7 +346,7 @@ def test_similarity_search_wih_score():
         )
 
 
-def test_similarity_search_by_vector_with_score():
+def test_similarity_search_by_vector_with_score() -> None:
     store, mocks = generalized_mock_factory()
 
     with (

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -5,6 +5,7 @@ from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
+import sqlalchemy
 from langchain_core.documents.base import Document
 
 from langchain_community.embeddings import FakeEmbeddings
@@ -12,7 +13,6 @@ from langchain_community.vectorstores.sqlserver import (
     DistanceStrategy,
     SQLServer_VectorStore,
 )
-import sqlalchemy
 
 EMBEDDING_LENGTH = 1536
 _ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO = str(
@@ -176,7 +176,7 @@ def test_create_engine() -> None:
         wraps=SQLServer_VectorStore._create_engine,
     ), patch.object(
         store, "_can_connect_with_entra_id", wraps=mocks["_can_connect_with_entra_id"]
-    ), patch.object(sqlalchemy, "create_engine", wraps=MagicMock), patch.object(
+    ), patch.object(sqlalchemy, "create_engine", wraps=MagicMock()), patch.object(
         store, "_provide_token", wraps=mocks["_provide_token"]
     ), patch("sqlalchemy.event.listen") as mock_listen:
         engine = store._create_engine(store)
@@ -202,7 +202,9 @@ def test_create_engine() -> None:
         wraps=SQLServer_VectorStore._create_engine,
     ), patch.object(
         store, "_can_connect_with_entra_id", wraps=mocks["_can_connect_with_entra_id"]
-    ), patch.object(store, "_provide_token", wraps=mocks["_provide_token"]), patch(
+    ), patch.object(
+        sqlalchemy, 'create_engine', wraps=MagicMock()
+    ),patch.object(store, "_provide_token", wraps=mocks["_provide_token"]), patch(
         "sqlalchemy.event.listen"
     ) as mock_listen:
         engine = store._create_engine(store)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -50,7 +50,7 @@ def generalized_mock_factory() -> None:
                 )
             )
 
-        connection_string = "mssql+pyodbc://abcde.database.windows.net,1433/iamvectorstore?driver=ODBC+Driver+17+for+SQL+Server"
+        connection_string = "mssql://abcde.database.windows.net,1433/iamvectorstore?driver=ODBC+Driver+17+for+SQL+Server"
         db_schema = "test_schema"
         distance_strategy = DistanceStrategy.DOT
         embedding_function = FakeEmbeddings(size=128)
@@ -76,7 +76,7 @@ def test_init():
     # Assert
     assert (
         store.connection_string
-        == "mssql+pyodbc://abcde.database.windows.net,1433/iamvectorstore?driver=ODBC+Driver+17+for+SQL+Server"
+        == "mssql://abcde.database.windows.net,1433/iamvectorstore?driver=ODBC+Driver+17+for+SQL+Server"
     )
     assert store._distance_strategy == DistanceStrategy.DOT
     assert store.embedding_function == FakeEmbeddings(size=128)

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -3,7 +3,7 @@ import json
 import unittest
 from contextlib import ExitStack
 from types import SimpleNamespace
-from typing import Optional
+from typing import Optional, Tuple
 from unittest.mock import MagicMock, Mock, patch
 
 import sqlalchemy
@@ -18,7 +18,7 @@ from langchain_community.vectorstores.sqlserver import (
 EMBEDDING_LENGTH = 1536
 
 
-def generalized_mock_factory() -> tuple[SQLServer_VectorStore, dict[str, MagicMock]]:
+def generalized_mock_factory() -> Tuple[SQLServer_VectorStore, dict[str, MagicMock]]:
     mocks = {
         "_create_engine": MagicMock(),
         "_prepare_json_data_type": MagicMock(),

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -3,6 +3,7 @@ import json
 import unittest
 from contextlib import ExitStack
 from types import SimpleNamespace
+from typing import Union
 from unittest.mock import MagicMock, Mock, patch
 
 import sqlalchemy
@@ -17,7 +18,7 @@ from langchain_community.vectorstores.sqlserver import (
 EMBEDDING_LENGTH = 1536
 
 
-def generalized_mock_factory() -> None:
+def generalized_mock_factory() -> Union[SQLServer_VectorStore, dict]:
     mocks = {
         "_create_engine": MagicMock(),
         "_prepare_json_data_type": MagicMock(),
@@ -127,8 +128,8 @@ def test_can_connect_with_entra_id() -> None:
 
         # case 3: parsed_url has trusted_connection=yes
         url_value = {
-            "username": None,
-            "password": None,
+            "username": "",
+            "password": "",
             "query": "trusted_connection=yes",
         }
 
@@ -148,8 +149,8 @@ def test_can_connect_with_entra_id() -> None:
         # case 4: parsed_url does not have trusted_connection=yes,
         #  no username and password
         url_value = {
-            "username": None,
-            "password": None,
+            "username": "",
+            "password": "",
             "query": "trusted_connection=no",
         }
 
@@ -271,18 +272,14 @@ def test_similarity_search() -> None:
 def test_similarity_search_by_vector() -> None:
     store, mocks = generalized_mock_factory()
 
-    with (
-        patch(
-            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore.similarity_search_by_vector",
-            wraps=SQLServer_VectorStore.similarity_search_by_vector,
-        ),
-        patch.object(
-            store,
-            "similarity_search_by_vector_with_score",
-            wraps=mocks["similarity_search_by_vector_with_score"],
-        ),
-        patch.object(store, "_docs_from_result", wraps=mocks["_docs_from_result"]),
-    ):
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore.similarity_search_by_vector",
+        wraps=SQLServer_VectorStore.similarity_search_by_vector,
+    ), patch.object(
+        store,
+        "similarity_search_by_vector_with_score",
+        wraps=mocks["similarity_search_by_vector_with_score"],
+    ), patch.object(store, "_docs_from_result", wraps=mocks["_docs_from_result"]):
         embeddings = [0.1, 0.2, 0.3]
         mock_responses = {
             tuple(["0.01", "0.02", "0.03"]): (
@@ -368,18 +365,14 @@ def test_similarity_search_wih_score() -> None:
 def test_similarity_search_by_vector_with_score() -> None:
     store, mocks = generalized_mock_factory()
 
-    with (
-        patch(
-            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore."
-            "similarity_search_by_vector_with_score",
-            wraps=SQLServer_VectorStore.similarity_search_by_vector_with_score,
-        ),
-        patch.object(store, "_search_store", wraps=mocks["_search_store"]),
-        patch.object(
-            store,
-            "_docs_and_scores_from_result",
-            wraps=mocks["_docs_and_scores_from_result"],
-        ),
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore."
+        "similarity_search_by_vector_with_score",
+        wraps=SQLServer_VectorStore.similarity_search_by_vector_with_score,
+    ), patch.object(store, "_search_store", wraps=mocks["_search_store"]), patch.object(
+        store,
+        "_docs_and_scores_from_result",
+        wraps=mocks["_docs_and_scores_from_result"],
     ):
         embeddings = tuple[0.01, 0.02, 0.03]
 
@@ -389,7 +382,7 @@ def test_similarity_search_by_vector_with_score() -> None:
                  0.9595672912317021)"""
         expected_docs = (
             Document(page_content="""Got these on sale for roughly 25 cents per cup"""),
-            0.9588668232580106,
+            "0.9588668232580106",
         )
 
         store._search_store.return_value = expected_search_result
@@ -418,7 +411,7 @@ def test_similarity_search_by_vector_with_score() -> None:
         assert result == expected_docs
 
 
-def test_add_texts():
+def test_add_texts() -> None:
     store, mocks = generalized_mock_factory()
 
     texts = ["hi", "hello", "welcome"]
@@ -457,7 +450,7 @@ def test_add_texts():
         )
 
 
-def test_create_filter_clause():
+def test_create_filter_clause() -> None:
     store, mocks = generalized_mock_factory()
 
     with patch(
@@ -545,7 +538,7 @@ def test_create_filter_clause():
         assert filter_clause_returned is None
 
 
-def test_handle_field_filter():
+def test_handle_field_filter() -> None:
     store, mocks = generalized_mock_factory()
 
     with patch(
@@ -674,7 +667,7 @@ def test_handle_field_filter():
         assert str(handle_field_filter_response) == expected_response
 
 
-def test_docs_from_result():
+def test_docs_from_result() -> None:
     store, mocks = generalized_mock_factory()
 
     with patch(
@@ -754,7 +747,7 @@ def test_docs_from_result():
         assert documents_returned == expected_documents
 
 
-def test_docs_and_scores_from_result():
+def test_docs_and_scores_from_result() -> None:
     store, mocks = generalized_mock_factory()
 
     with patch(
@@ -778,18 +771,13 @@ def test_docs_and_scores_from_result():
         assert resulted_docs_and_score == expected_documents
 
 
-def test_delete():
+def test_delete() -> None:
     store, mocks = generalized_mock_factory()
 
-    with (
-        patch(
-            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore.delete",
-            wraps=SQLServer_VectorStore.delete,
-        ),
-        patch.object(
-            store, "_delete_texts_by_ids", wraps=mocks["_delete_texts_by_ids"]
-        ),
-    ):
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore.delete",
+        wraps=SQLServer_VectorStore.delete,
+    ), patch.object(store, "_delete_texts_by_ids", wraps=mocks["_delete_texts_by_ids"]):
         ids = None
         assert store.delete(store, ids) is False
 

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -173,7 +173,8 @@ def test_can_connect_with_entra_id() -> None:
 #     # Unpatch _create_engine to call the actual method
 #     with (
 #         patch(
-#             "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
+#             "langchain_community.vectorstores.sqlserver.
+# SQLServer_VectorStore._create_engine",
 #             wraps=SQLServer_VectorStore._create_engine,
 #         ),
 #         patch.object(
@@ -192,7 +193,8 @@ def test_can_connect_with_entra_id() -> None:
 #     mocks["_can_connect_with_entra_id"].assert_called_once()
 #     if mocks["_can_connect_with_entra_id"].return_value:
 #         specific_calls = [
-#             call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
+#             call for call in mock_listen.call_args_list if call.args[1] ==
+#  "do_connect"
 #         ]
 #         assert len(specific_calls) == 1, f"""Expected 'do_connect' to be called once.
 #           Called {len(specific_calls)} times."""
@@ -206,7 +208,8 @@ def test_can_connect_with_entra_id() -> None:
 #     mocks["_can_connect_with_entra_id"].return_value = False
 #     with (
 #         patch(
-#             "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
+#             "langchain_community.vectorstores.sqlserver.
+# SQLServer_VectorStore._create_engine",
 #             wraps=SQLServer_VectorStore._create_engine,
 #         ),
 #         patch.object(
@@ -464,7 +467,7 @@ def test_create_filter_clause():
         patch.object(
             store, "_handle_field_filter", wraps=mocks["_handle_field_filter"]
         ),
-        patch.object(sqlalchemy, "and_", wraps=MagicMock) as mock_sqlalchemy_and,
+        patch.object(sqlalchemy, "and_", wraps=MagicMock) as mock_sqlalchemy_and
     ):
         # filter case 0: Filters is not dict
         filter_value = ["hi"]

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -459,16 +459,13 @@ def test_add_texts():
 
 def test_create_filter_clause():
     store, mocks = generalized_mock_factory()
-    with (
-        patch(
-            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_filter_clause",
-            wraps=SQLServer_VectorStore._create_filter_clause,
-        ),
-        patch.object(
-            store, "_handle_field_filter", wraps=mocks["_handle_field_filter"]
-        ),
-        patch("sqlalchemy.and_", wraps=MagicMock) as mock_sqlalchemy_and,
-    ):
+
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_filter_clause",
+        wraps=SQLServer_VectorStore._create_filter_clause,
+    ), patch.object(
+        store, "_handle_field_filter", wraps=mocks["_handle_field_filter"]
+    ), patch("sqlalchemy.and_", wraps=MagicMock()) as mock_sqlalchemy_and:
         # filter case 0: Filters is not dict
         filter_value = ["hi"]
 
@@ -551,18 +548,21 @@ def test_create_filter_clause():
 def test_handle_field_filter():
     store, mocks = generalized_mock_factory()
 
-    with (
-        patch(
-            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._handle_field_filter",
-            wraps=SQLServer_VectorStore._handle_field_filter,
-        ),
-        patch("sqlalchemy.and_", wraps=MagicMock) as mock_sqlalchemy_and,
-        patch.object(sqlalchemy, "or_", wraps=MagicMock),
-        patch("sqlalchemy.sql.operators.ne", wraps=MagicMock) as mock_sqlalchemy_ne,
-        patch("sqlalchemy.sql.operators.lt", wraps=MagicMock) as mock_sqlalchemy_lt,
-        patch("sqlalchemy.sql.operators.ge", wraps=MagicMock) as mock_sqlalchemy_gte,
-        patch("sqlalchemy.sql.operators.le", wraps=MagicMock) as mock_sqlalchemy_lte,
-    ):
+    with patch(
+        "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._handle_field_filter",
+        wraps=SQLServer_VectorStore._handle_field_filter,
+    ), patch("sqlalchemy.and_", wraps=MagicMock) as mock_sqlalchemy_and, patch.object(
+        sqlalchemy, "or_", wraps=MagicMock
+    ), patch(
+        "sqlalchemy.sql.operators.ne", wraps=MagicMock
+    ) as mock_sqlalchemy_ne, patch(
+        "sqlalchemy.sql.operators.lt", wraps=MagicMock
+    ) as mock_sqlalchemy_lt, patch(
+        "sqlalchemy.sql.operators.ge", wraps=MagicMock
+    ) as mock_sqlalchemy_gte, patch(
+        "sqlalchemy.sql.operators.le",
+        wraps=MagicMock,
+    ) as mock_sqlalchemy_lte:
         # Test case 1: field startWith $
         field = "$AND"
         value = 1

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -1,6 +1,5 @@
 # Unit test class
 import json
-import os
 import unittest
 from contextlib import ExitStack
 from types import SimpleNamespace
@@ -16,9 +15,6 @@ from langchain_community.vectorstores.sqlserver import (
 )
 
 EMBEDDING_LENGTH = 1536
-_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO = str(
-    os.environ.get("TEST_ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO")
-)
 
 
 def generalized_mock_factory() -> None:
@@ -54,7 +50,7 @@ def generalized_mock_factory() -> None:
                 )
             )
 
-        connection_string = _ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO
+        connection_string = "mssql+pyodbc://abcde.database.windows.net,1433/iamvectorstore?driver=ODBC+Driver+17+for+SQL+Server"
         db_schema = "test_schema"
         distance_strategy = DistanceStrategy.DOT
         embedding_function = FakeEmbeddings(size=128)
@@ -78,7 +74,10 @@ def test_init():
     store, mocks = generalized_mock_factory()
 
     # Assert
-    assert store.connection_string == _ENTRA_ID_CONNECTION_STRING_TRUSTED_CONNECTION_NO
+    assert (
+        store.connection_string
+        == "mssql+pyodbc://abcde.database.windows.net,1433/iamvectorstore?driver=ODBC+Driver+17+for+SQL+Server"
+    )
     assert store._distance_strategy == DistanceStrategy.DOT
     assert store.embedding_function == FakeEmbeddings(size=128)
     assert store._embedding_length == 128

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -374,7 +374,7 @@ def test_similarity_search_by_vector_with_score() -> None:
         "_docs_and_scores_from_result",
         wraps=mocks["_docs_and_scores_from_result"],
     ):
-        embeddings = tuple[0.01, 0.02, 0.03]
+        embeddings = tuple([0.01, 0.02, 0.03])
 
         expected_search_result = """(<langchain_community.vectorstores.sqlserver.
            SQLServer_VectorStore._get_embedding_store.<locals>.EmbeddingStore object

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -166,77 +166,6 @@ def test_can_connect_with_entra_id() -> None:
         assert result is True
 
 
-# def test_create_engine() -> None:
-#     # Arrange
-#     store, mocks = generalized_mock_factory()
-#     mocks["_can_connect_with_entra_id"].return_value = True
-#
-#     # Unpatch _create_engine to call the actual method
-#     with (
-#         patch(
-#             "langchain_community.vectorstores.sqlserver.
-# SQLServer_VectorStore._create_engine",
-#             wraps=SQLServer_VectorStore._create_engine,
-#         ),
-#         patch.object(
-#             store,
-#             "_can_connect_with_entra_id",
-#             wraps=mocks["_can_connect_with_entra_id"],
-#         ),
-#         patch.object(store, "_provide_token", wraps=mocks["_provide_token"]),
-#         patch("sqlalchemy.event.listen") as mock_listen,
-#         patch.object(
-#             sqlalchemy, "create_engine", wraps=MagicMock()
-#         ) as mock_create_engine,
-#     ):
-#         engine = store._create_engine(store)
-#
-#     mocks["_can_connect_with_entra_id"].assert_called_once()
-#     if mocks["_can_connect_with_entra_id"].return_value:
-#         specific_calls = [
-#             call for call in mock_listen.call_args_list if call.args[1] ==
-#  "do_connect"
-#         ]
-#         assert len(specific_calls) == 1, f"""Expected 'do_connect' to be called once.
-#           Called {len(specific_calls)} times."""
-#         specific_calls[0].assert_called_once_with(
-#             engine, "do_connect", store._provide_token, once=True
-#         )
-#
-#     mock_listen.reset_mock()
-#     mocks["_can_connect_with_entra_id"].reset_mock()
-#
-#     mocks["_can_connect_with_entra_id"].return_value = False
-#     with (
-#         patch(
-#             "langchain_community.vectorstores.sqlserver.
-# SQLServer_VectorStore._create_engine",
-#             wraps=SQLServer_VectorStore._create_engine,
-#         ),
-#         patch.object(
-#             store,
-#             "_can_connect_with_entra_id",
-#             wraps=mocks["_can_connect_with_entra_id"],
-#         ),
-#         patch.object(
-#             sqlalchemy, "create_engine", wraps=MagicMock
-#         ) as mock_create_engine,
-#         patch.object(store, "_provide_token", wraps=mocks["_provide_token"]),
-#         patch("sqlalchemy.event.listen") as mock_listen,
-#     ):
-#         engine = store._create_engine(store)
-#
-#     mock_create_engine.return_value = MagicMock()
-#     mocks["_can_connect_with_entra_id"].assert_called_once()
-#
-#     specific_calls = [
-#         call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
-#     ]
-#     assert (
-#         len(specific_calls) == 0
-#     ), f"Expected 'do_connect' to be called once. Called {len(specific_calls)} times."
-
-
 def test_similarity_search() -> None:
     store, mocks = generalized_mock_factory()
 
@@ -399,7 +328,6 @@ def test_similarity_search_by_vector_with_score() -> None:
         )
         assert result == expected_docs
 
-        store.similarity_search_by_vector_with_score.reset_mock()
         mocks["_docs_and_scores_from_result"].reset_mock()
         mocks["_search_store"].reset_mock()
 
@@ -787,9 +715,9 @@ def test_delete() -> None:
         assert store.delete(store, ids) is False
 
         ids = [1, 2, 3]
-        store._delete_texts_by_ids.return_value = 0
+        mocks["_delete_texts_by_ids"].return_value = 0
         assert store.delete(store, ids) is False
 
         ids = [1, 2, 3]
-        store._delete_texts_by_ids.return_value = 1
+        mocks["_delete_texts_by_ids"].return_value = 1
         assert store.delete(store, ids) is True

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -165,73 +165,72 @@ def test_can_connect_with_entra_id() -> None:
         assert result is True
 
 
-def test_create_engine() -> None:
-    # Arrange
-    store, mocks = generalized_mock_factory()
-    mocks["_can_connect_with_entra_id"].return_value = True
-
-    # Unpatch _create_engine to call the actual method
-    with (
-        patch(
-            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
-            wraps=SQLServer_VectorStore._create_engine,
-        ),
-        patch.object(
-            store,
-            "_can_connect_with_entra_id",
-            wraps=mocks["_can_connect_with_entra_id"],
-        ),
-        patch.object(store, "_provide_token", wraps=mocks["_provide_token"]),
-        patch("sqlalchemy.event.listen") as mock_listen,
-        patch.object(
-            sqlalchemy, "create_engine", wraps=MagicMock()
-        ) as mock_create_engine,
-    ):
-        engine = store._create_engine(store)
-
-    mocks["_can_connect_with_entra_id"].assert_called_once()
-    mock_create_engine.return_value = MagicMock()
-    if mocks["_can_connect_with_entra_id"].return_value:
-        specific_calls = [
-            call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
-        ]
-        assert len(specific_calls) == 1, f"""Expected 'do_connect' to be called once.
-          Called {len(specific_calls)} times."""
-        specific_calls[0].assert_called_once_with(
-            engine, "do_connect", store._provide_token, once=True
-        )
-
-    mock_listen.reset_mock()
-    mocks["_can_connect_with_entra_id"].reset_mock()
-
-    mocks["_can_connect_with_entra_id"].return_value = False
-    with (
-        patch(
-            "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
-            wraps=SQLServer_VectorStore._create_engine,
-        ),
-        patch.object(
-            store,
-            "_can_connect_with_entra_id",
-            wraps=mocks["_can_connect_with_entra_id"],
-        ),
-        patch.object(
-            sqlalchemy, "create_engine", wraps=MagicMock
-        ) as mock_create_engine,
-        patch.object(store, "_provide_token", wraps=mocks["_provide_token"]),
-        patch("sqlalchemy.event.listen") as mock_listen,
-    ):
-        engine = store._create_engine(store)
-
-    mock_create_engine.return_value = MagicMock()
-    mocks["_can_connect_with_entra_id"].assert_called_once()
-
-    specific_calls = [
-        call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
-    ]
-    assert (
-        len(specific_calls) == 0
-    ), f"Expected 'do_connect' to be called once. Called {len(specific_calls)} times."
+# def test_create_engine() -> None:
+#     # Arrange
+#     store, mocks = generalized_mock_factory()
+#     mocks["_can_connect_with_entra_id"].return_value = True
+#
+#     # Unpatch _create_engine to call the actual method
+#     with (
+#         patch(
+#             "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
+#             wraps=SQLServer_VectorStore._create_engine,
+#         ),
+#         patch.object(
+#             store,
+#             "_can_connect_with_entra_id",
+#             wraps=mocks["_can_connect_with_entra_id"],
+#         ),
+#         patch.object(store, "_provide_token", wraps=mocks["_provide_token"]),
+#         patch("sqlalchemy.event.listen") as mock_listen,
+#         patch.object(
+#             sqlalchemy, "create_engine", wraps=MagicMock()
+#         ) as mock_create_engine,
+#     ):
+#         engine = store._create_engine(store)
+#
+#     mocks["_can_connect_with_entra_id"].assert_called_once()
+#     if mocks["_can_connect_with_entra_id"].return_value:
+#         specific_calls = [
+#             call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
+#         ]
+#         assert len(specific_calls) == 1, f"""Expected 'do_connect' to be called once.
+#           Called {len(specific_calls)} times."""
+#         specific_calls[0].assert_called_once_with(
+#             engine, "do_connect", store._provide_token, once=True
+#         )
+#
+#     mock_listen.reset_mock()
+#     mocks["_can_connect_with_entra_id"].reset_mock()
+#
+#     mocks["_can_connect_with_entra_id"].return_value = False
+#     with (
+#         patch(
+#             "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_engine",
+#             wraps=SQLServer_VectorStore._create_engine,
+#         ),
+#         patch.object(
+#             store,
+#             "_can_connect_with_entra_id",
+#             wraps=mocks["_can_connect_with_entra_id"],
+#         ),
+#         patch.object(
+#             sqlalchemy, "create_engine", wraps=MagicMock
+#         ) as mock_create_engine,
+#         patch.object(store, "_provide_token", wraps=mocks["_provide_token"]),
+#         patch("sqlalchemy.event.listen") as mock_listen,
+#     ):
+#         engine = store._create_engine(store)
+#
+#     mock_create_engine.return_value = MagicMock()
+#     mocks["_can_connect_with_entra_id"].assert_called_once()
+#
+#     specific_calls = [
+#         call for call in mock_listen.call_args_list if call.args[1] == "do_connect"
+#     ]
+#     assert (
+#         len(specific_calls) == 0
+#     ), f"Expected 'do_connect' to be called once. Called {len(specific_calls)} times."
 
 
 def test_similarity_search() -> None:

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -252,13 +252,15 @@ def test_similarity_search() -> None:
         store.embedding_function = Mock()
         store.embedding_function.embed_query = Mock()
         store.embedding_function.embed_query.return_value = mock_responses[query]
-        store.similarity_search_by_vector.return_value = mock_responses
+        mocks["similarity_search_by_vector"].return_value = mock_responses
 
         store.similarity_search(store, query)
 
-        store.similarity_search_by_vector.assert_called_once_with([0.01, 0.02, 0.03], 4)
+        mocks["similarity_search_by_vector"].assert_called_once_with(
+            [0.01, 0.02, 0.03], 4
+        )
 
-        store.similarity_search_by_vector.reset_mock()
+        mocks["similarity_search_by_vector"].reset_mock()
 
         query = "hello"
         store.embedding_function.embed_query.reset_mock()
@@ -266,7 +268,7 @@ def test_similarity_search() -> None:
 
         store.similarity_search(store, query, 7)
 
-        store.similarity_search_by_vector.assert_called_once_with([0.1, 0.2, 0.3], 7)
+        mocks["similarity_search_by_vector"].assert_called_once_with([0.1, 0.2, 0.3], 7)
 
 
 def test_similarity_search_by_vector() -> None:
@@ -294,32 +296,32 @@ def test_similarity_search_by_vector() -> None:
             0.9588668232580106,
         )
 
-        store.similarity_search_by_vector_with_score.return_value = mock_responses[
+        mocks["similarity_search_by_vector_with_score"].return_value = mock_responses[
             tuple(["0.01", "0.02", "0.03"])
         ]
-        store._docs_from_result.return_value = expected_result
+        mocks["_docs_from_result"].return_value = expected_result
 
         store.similarity_search_by_vector(store, embeddings)
 
-        store.similarity_search_by_vector_with_score.assert_called_once_with(
+        mocks["similarity_search_by_vector_with_score"].assert_called_once_with(
             embeddings, 4
         )
-        store._docs_from_result.assert_called_once_with(
+        mocks["_docs_from_result"].assert_called_once_with(
             mock_responses[tuple(["0.01", "0.02", "0.03"])]
         )
 
-        store.similarity_search_by_vector_with_score.reset_mock()
-        store._docs_from_result.reset_mock()
+        mocks["similarity_search_by_vector_with_score"].reset_mock()
+        mocks["_docs_from_result"].reset_mock()
 
         store.similarity_search_by_vector(store, embeddings, 7)
 
-        store._docs_from_result.assert_called_once_with(
+        mocks["_docs_from_result"].assert_called_once_with(
             mock_responses[tuple(["0.01", "0.02", "0.03"])]
         )
-        store.similarity_search_by_vector_with_score.assert_called_once_with(
+        mocks["similarity_search_by_vector_with_score"].assert_called_once_with(
             [0.1, 0.2, 0.3], 7
         )
-        store._docs_from_result.assert_called_once_with(
+        mocks["_docs_from_result"].assert_called_once_with(
             mock_responses[tuple(["0.01", "0.02", "0.03"])]
         )
 
@@ -341,15 +343,15 @@ def test_similarity_search_wih_score() -> None:
         store.embedding_function = Mock()
         store.embedding_function.embed_query = Mock()
         store.embedding_function.embed_query.return_value = mock_responses[query]
-        store.similarity_search_by_vector_with_score.return_value = mock_responses
+        mocks["similarity_search_by_vector_with_score"].return_value = mock_responses
 
         store.similarity_search_with_score(store, query)
 
-        store.similarity_search_by_vector_with_score.assert_called_once_with(
+        mocks["similarity_search_by_vector_with_score"].assert_called_once_with(
             [0.01, 0.02, 0.03], 4
         )
 
-        store.similarity_search_by_vector_with_score.reset_mock()
+        mocks["similarity_search_by_vector_with_score"].reset_mock()
 
         query = "hello"
         store.embedding_function.embed_query.reset_mock()
@@ -357,7 +359,7 @@ def test_similarity_search_wih_score() -> None:
 
         store.similarity_search_with_score(store, query, 7)
 
-        store.similarity_search_by_vector_with_score.assert_called_once_with(
+        mocks["similarity_search_by_vector_with_score"].assert_called_once_with(
             [0.1, 0.2, 0.3], 7
         )
 
@@ -385,27 +387,27 @@ def test_similarity_search_by_vector_with_score() -> None:
             "0.9588668232580106",
         )
 
-        store._search_store.return_value = expected_search_result
-        store._docs_and_scores_from_result.return_value = expected_docs
+        mocks["_search_store"].return_value = expected_search_result
+        mocks["_docs_and_scores_from_result"].return_value = expected_docs
 
         # case 1: k is not given
         result = store.similarity_search_by_vector_with_score(store, embeddings)
 
-        store._search_store.assert_called_once_with(embeddings, 4)
-        store._docs_and_scores_from_result.assert_called_once_with(
+        mocks["_search_store"].assert_called_once_with(embeddings, 4)
+        mocks["_docs_and_scores_from_result"].assert_called_once_with(
             expected_search_result
         )
         assert result == expected_docs
 
         store.similarity_search_by_vector_with_score.reset_mock()
-        store._docs_and_scores_from_result.reset_mock()
-        store._search_store.reset_mock()
+        mocks["_docs_and_scores_from_result"].reset_mock()
+        mocks["_search_store"].reset_mock()
 
         # case 2: k =7
         result = store.similarity_search_by_vector_with_score(store, embeddings, 7)
 
-        store._search_store.assert_called_once_with(embeddings, 7)
-        store._docs_and_scores_from_result.assert_called_once_with(
+        mocks["_search_store"].assert_called_once_with(embeddings, 7)
+        mocks["_docs_and_scores_from_result"].assert_called_once_with(
             expected_search_result
         )
         assert result == expected_docs
@@ -431,21 +433,21 @@ def test_add_texts() -> None:
         store.embedding_function = Mock()
         store.embedding_function.embed_documents = Mock()
         store.embedding_function.embed_documents.return_value = embeddings
-        store._insert_embeddings.return_value = ids
+        mocks["_insert_embeddings"].return_value = ids
 
         # case 1:input ids not given
         returned_ids = store.add_texts(store, texts, metadatas)
         assert returned_ids == ids
-        store._insert_embeddings.assert_called_once_with(
+        mocks["_insert_embeddings"].assert_called_once_with(
             texts, embeddings, metadatas, None
         )
 
-        store._insert_embeddings.reset_mock()
+        mocks["_insert_embeddings"].reset_mock()
 
         # case 1:input ids not given
         returned_ids = store.add_texts(store, texts, metadatas, input_ids)
         assert returned_ids == ids
-        store._insert_embeddings.assert_called_once_with(
+        mocks["_insert_embeddings"].assert_called_once_with(
             texts, embeddings, metadatas, input_ids
         )
 
@@ -481,12 +483,12 @@ def test_create_filter_clause() -> None:
         filter_value_2 = {"id": 1}
         expected_filter_clause = """JSON_VALUE(langchain_vector_store_tests.
         content_metadata, :JSON_VALUE_1) = :JSON_VALUE_2"""
-        store._handle_field_filter.return_value = expected_filter_clause
+        mocks["_handle_field_filter"].return_value = expected_filter_clause
 
         filter_clause_returned = store._create_filter_clause(store, filter_value_2)
         assert filter_clause_returned == expected_filter_clause
-        store._handle_field_filter.assert_called_once_with("id", 1)
-        store._handle_field_filter.reset_mock()
+        mocks["_handle_field_filter"].assert_called_once_with("id", 1)
+        mocks["_handle_field_filter"].reset_mock()
 
         # filter case 3 - Filter value is not list
         filter_value_2 = {"$or": {"hi"}}
@@ -497,7 +499,7 @@ def test_create_filter_clause() -> None:
             str(context.exception)
             == """Expected a list, but got <class 'set'> for value: {'hi'}"""
         )
-        store._handle_field_filter.reset_mock()
+        mocks["_handle_field_filter"].reset_mock()
 
         # filter case 4 - length of fields >1 and have operator, not fields
         filter_value_4 = {"$eq": {}, "$gte": 1}
@@ -507,7 +509,7 @@ def test_create_filter_clause() -> None:
             str(context.exception)
             == """Invalid filter condition. Expected a field but got: $eq"""
         )
-        store._handle_field_filter.reset_mock()
+        mocks["_handle_field_filter"].reset_mock()
 
         # filter case 5 - length of fields > 1 and have all fields, we AND it together
 
@@ -523,11 +525,11 @@ def test_create_filter_clause() -> None:
         )
         mock_sqlalchemy_and.return_value = expected_filter_clause
         store._create_filter_clause(store, filter_value_5)
-        assert store._handle_field_filter.call_count == 2
-        store._handle_field_filter.reset_mock()
+        assert mocks["_handle_field_filter"].call_count == 2
+        mocks["_handle_field_filter"].reset_mock()
 
         # filter case 6 - empty dictionary
-        filter_value_6 = {}
+        filter_value_6: Dict = {}
         with unittest.TestCase().assertRaises(ValueError) as context:
             store._create_filter_clause(store, filter_value_6)
         assert str(context.exception) == """Got an empty dictionary for filters."""
@@ -641,7 +643,7 @@ def test_handle_field_filter() -> None:
 
         # Test case 8: SPECIAL CASED OPERATOR unsupported
         field = "id"
-        value_6 = {"$in": [[], []]}
+        value_6: Dict = {"$in": [[], []]}
         with unittest.TestCase().assertRaises(NotImplementedError) as context_n:
             store._handle_field_filter(store, field, value_6)
         assert (

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -3,7 +3,7 @@ import json
 import unittest
 from contextlib import ExitStack
 from types import SimpleNamespace
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 from unittest.mock import MagicMock, Mock, patch
 
 import sqlalchemy
@@ -18,7 +18,7 @@ from langchain_community.vectorstores.sqlserver import (
 EMBEDDING_LENGTH = 1536
 
 
-def generalized_mock_factory() -> Tuple[SQLServer_VectorStore, dict[str, MagicMock]]:
+def generalized_mock_factory() -> Tuple[SQLServer_VectorStore, Dict[str, MagicMock]]:
     mocks = {
         "_create_engine": MagicMock(),
         "_prepare_json_data_type": MagicMock(),

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -467,7 +467,7 @@ def test_create_filter_clause():
         patch.object(
             store, "_handle_field_filter", wraps=mocks["_handle_field_filter"]
         ),
-        patch.object(sqlalchemy, "and_", wraps=MagicMock) as mock_sqlalchemy_and
+        patch("sqlalchemy.and_", wraps=MagicMock) as mock_sqlalchemy_and,
     ):
         # filter case 0: Filters is not dict
         filter_value = ["hi"]
@@ -556,20 +556,12 @@ def test_handle_field_filter():
             "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._handle_field_filter",
             wraps=SQLServer_VectorStore._handle_field_filter,
         ),
-        patch.object(sqlalchemy, "and_", wraps=MagicMock) as mock_sqlalchemy_and,
+        patch("sqlalchemy.and_", wraps=MagicMock) as mock_sqlalchemy_and,
         patch.object(sqlalchemy, "or_", wraps=MagicMock),
-        patch.object(
-            sqlalchemy.sql.operators, "ne", wraps=MagicMock
-        ) as mock_sqlalchemy_ne,
-        patch.object(
-            sqlalchemy.sql.operators, "lt", wraps=MagicMock
-        ) as mock_sqlalchemy_lt,
-        patch.object(
-            sqlalchemy.sql.operators, "ge", wraps=MagicMock
-        ) as mock_sqlalchemy_gte,
-        patch.object(
-            sqlalchemy.sql.operators, "le", wraps=MagicMock
-        ) as mock_sqlalchemy_lte,
+        patch("sqlalchemy.sql.operators.ne", wraps=MagicMock) as mock_sqlalchemy_ne,
+        patch("sqlalchemy.sql.operators.lt", wraps=MagicMock) as mock_sqlalchemy_lt,
+        patch("sqlalchemy.sql.operators.ge", wraps=MagicMock) as mock_sqlalchemy_gte,
+        patch("sqlalchemy.sql.operators.le", wraps=MagicMock) as mock_sqlalchemy_lte,
     ):
         # Test case 1: field startWith $
         field = "$AND"

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver_unit.py
@@ -461,12 +461,11 @@ def test_create_filter_clause():
         patch(
             "langchain_community.vectorstores.sqlserver.SQLServer_VectorStore._create_filter_clause",
             wraps=SQLServer_VectorStore._create_filter_clause,
-        ) as mock_create_filter_clause,
+        ),
         patch.object(
             store, "_handle_field_filter", wraps=mocks["_handle_field_filter"]
         ),
         patch.object(sqlalchemy, "and_", wraps=MagicMock) as mock_sqlalchemy_and,
-        patch.object(sqlalchemy, "or_", wraps=MagicMock) as mock_sqlalachemy_or,
     ):
         # filter case 0: Filters is not dict
         filter_value = ["hi"]


### PR DESCRIPTION
## Why make this change?
This PR contains unit tests for the following functions in sqlserver.py

init
_can_connect_with_entra_id
_similarity_search
_similarity_search_by_vector
_similarity_search_wih_score
_similarity_search_by_vector_with_score
 _add_texts
_create_filter_clause
 _handle_field_filter
 _docs_from_result
 _docs_and_scores_from_result
delete

## Why are these changes needed?
These changes are required to ensure the complete code is checked for any potential bugs, by mocking the actual implementations of private functions/API calls. A good coverage also ensures good engineering practices. A wide range of test cases were covered to allow the code to flow all lines of codes.

## What is the current code coverage?
With these tests the current code coverage is 61%.

## How was this tested?
All these tests were run locally to verify success and coverage percentage.

## What needs to be done next?
https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/3428633/?view=edit
 This work item contains a detailed explanation on the pending work.

## Note
Earlier 2 PRs were created, but after looking at the LINT issue, realized 1 PR is good to address any upcoming LINT issues at once. So, the earlier PR is cancelled and this PR contains all unit test changes.

<img width="1459" alt="image" src="https://github.com/user-attachments/assets/ffc6a0e4-25b5-483f-b9d6-8381acce9568">

