### PR TITLE
Update DELETE API

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -815,7 +815,7 @@ class SQLServer_VectorStore(VectorStore):
             raise
         return ids
 
-    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> bool:
+    def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
         """Delete embeddings in the vectorstore by the ids.
 
         Args:
@@ -826,6 +826,10 @@ class SQLServer_VectorStore(VectorStore):
         Returns:
             Optional[bool]
         """
+
+        if ids is not None and len(ids) == 0:
+            logging.info(EMPTY_IDS_ERROR_MESSAGE)
+            return False
 
         result = self._delete_texts_by_ids(ids)
         if result == 0:

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -820,7 +820,7 @@ class SQLServer_VectorStore(VectorStore):
 
         Args:
             ids: List of IDs to delete. If None, delete all. Default is None.
-                No data is deleted is empty list is provided.
+                No data is deleted if empty list is provided.
             kwargs: vectorstore specific parameters.
 
         Returns:

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -820,6 +820,7 @@ class SQLServer_VectorStore(VectorStore):
 
         Args:
             ids: List of IDs to delete. If None, delete all. Default is None.
+                No data is deleted is empty list is provided.
             kwargs: vectorstore specific parameters.
 
         Returns:
@@ -837,7 +838,7 @@ class SQLServer_VectorStore(VectorStore):
     def _delete_texts_by_ids(self, ids: Optional[List[str]] = None) -> int:
         try:
             with Session(bind=self._bind) as session:
-                if ids is None or len(ids) == 0:
+                if ids is None:
                     logging.info("Deleting all data in the vectorstore.")
                     result = session.query(self._embedding_store).delete()
                 else:

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -318,7 +318,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     store.add_texts(texts, metadatas)
 
     result = store.delete(None)
-    # Should return False, since empty list of ids given
+    # Should return True, since empty list of ids given
     assert result
 
 

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -313,13 +313,30 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     texts: List[str],
     metadatas: List[dict],
 ) -> None:
-    """Test that delete API deletes texts by id."""
+    """Test that delete API deletes data in vectorstore
+    when `None` is provided as the parameter."""
 
     store.add_texts(texts, metadatas)
-
     result = store.delete(None)
-    # Should return True, since empty list of ids given
+
+    # Should return True, since None is provided,
+    # all data in vectorstore is deleted.
     assert result
+
+
+def test_sqlserver_delete_text_by_id_empty_list_provided(
+    store: SQLServer_VectorStore,
+    texts: List[str],
+    metadatas: List[dict],
+) -> None:
+    """Test that delete API does not delete data
+    if empty list of ID is provided."""
+
+    store.add_texts(texts, metadatas)
+    result = store.delete([])
+
+    # Should return False, since empty list of ids given
+    assert not result
 
 
 def test_that_multiple_vector_stores_can_be_created(

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -277,8 +277,7 @@ def test_sqlserver_delete_text_by_id_valid_ids_provided(
 
     result = store.delete(["1", "2", "5"])
     # Should return true since valid ids are given
-    if result:
-        pass
+    assert result
 
 
 def test_sqlserver_delete_text_by_id_valid_id_and_invalid_ids_provided(
@@ -292,8 +291,7 @@ def test_sqlserver_delete_text_by_id_valid_id_and_invalid_ids_provided(
 
     result = store.delete(["1", "2", "6", "9"])
     # Should return true since valid ids are given
-    if result:
-        pass
+    assert result
 
 
 def test_sqlserver_delete_text_by_id_invalid_ids_provided(
@@ -307,8 +305,7 @@ def test_sqlserver_delete_text_by_id_invalid_ids_provided(
 
     result = store.delete(["100000"])
     # Should return False since given id is not in DB
-    if not result:
-        pass
+    assert not result
 
 
 def test_sqlserver_delete_text_by_id_no_ids_provided(
@@ -322,8 +319,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
 
     result = store.delete(None)
     # Should return False, since empty list of ids given
-    if not result:
-        pass
+    assert result
 
 
 def test_that_multiple_vector_stores_can_be_created(

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -322,7 +322,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     # Should return True, since None is provided,
     # all data in vectorstore is deleted.
     assert result
-    
+
     # Check that length of data in vectorstore after
     # delete has been invoked is zero.
     conn = create_engine(_CONNECTION_STRING).connect()

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -313,7 +313,7 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     texts: List[str],
     metadatas: List[dict],
 ) -> None:
-    """Test that delete API deletes data in vectorstore
+    """Test that delete API deletes all data in vectorstore
     when `None` is provided as the parameter."""
 
     store.add_texts(texts, metadatas)
@@ -322,6 +322,14 @@ def test_sqlserver_delete_text_by_id_no_ids_provided(
     # Should return True, since None is provided,
     # all data in vectorstore is deleted.
     assert result
+    
+    # Check that length of data in vectorstore after
+    # delete has been invoked is zero.
+    conn = create_engine(_CONNECTION_STRING).connect()
+    data = conn.execute(text(f"select * from {_TABLE_NAME}")).fetchall()
+    conn.close()
+
+    assert len(data) == 0, f"VectorStore {_TABLE_NAME} is not empty."
 
 
 def test_sqlserver_delete_text_by_id_empty_list_provided(


### PR DESCRIPTION
## Why make this change?
In respect to the latest documentation from [LangChain](https://python.langchain.com/api_reference/core/vectorstores/langchain_core.vectorstores.base.VectorStore.html#langchain_core.vectorstores.base.VectorStore.delete) with regards to the delete API, this change aims to update the `delete` implementation to fit the documentation.

## What is this change?
In this PR:
- We ensure that if `None` is provided when `delete` function is executed, we delete all the data in the table. An empty list does not cause data to be deleted from the vectorstore. Existing test `test_sqlserver_delete_text_by_id_no_ids_provided` is updated to reflect this. 
- For the test change, with the previous implementation, even if a test condition fails, the test does not fail/error out. The assert statements ensure that the results from the function calls influence the test result.
- The following tests are updated to use assert statements.
  - test_sqlserver_delete_text_by_id_valid_ids_provided
  - test_sqlserver_delete_text_by_id_valid_id_and_invalid_ids_provided
  - test_sqlserver_delete_text_by_id_no_ids_provided
  - test_sqlserver_delete_text_by_id_invalid_ids_provided