### PR TITLE
Implement from_texts & from_documents

### DIFF
--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -325,10 +325,10 @@ class SQLServer_VectorStore(VectorStore):
     @classmethod
     def from_texts(
         cls: Type[SQLServer_VectorStore],
-        *,
         texts: List[str],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
+        *,
         connection_string: str,
         embedding_length: int,
         table_name: str,
@@ -382,9 +382,9 @@ class SQLServer_VectorStore(VectorStore):
     @classmethod
     def from_documents(
         cls: Type[SQLServer_VectorStore],
-        *,
         documents: List[Document],
         embedding: Embeddings,
+        *,
         connection_string: str,
         embedding_length: int,
         table_name: str,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -256,8 +256,8 @@ class SQLServer_VectorStore(VectorStore):
 
     def _get_embedding_store(self, name: str, schema: Optional[str]) -> Any:
         DynamicBase = declarative_base(class_registry=dict())  # type: Any
-        if self._embedding_length is None:
-            raise ValueError("Expected a value for embedding_length but got `None`.")
+        if self._embedding_length is None or self._embedding_length < 1:
+            raise ValueError("`embedding_length` value is not valid.")
 
         class EmbeddingStore(DynamicBase):
             """This is the base model for SQL vector store."""
@@ -333,7 +333,7 @@ class SQLServer_VectorStore(VectorStore):
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
         connection_string: str = str(),
-        embedding_length: Optional[int] = None,
+        embedding_length: int = 0,
         table_name: str = DEFAULT_TABLE_NAME,
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
@@ -388,7 +388,7 @@ class SQLServer_VectorStore(VectorStore):
         documents: List[Document],
         embedding: Embeddings,
         connection_string: str = str(),
-        embedding_length: Optional[int] = None,
+        embedding_length: int = 0,
         table_name: str = DEFAULT_TABLE_NAME,
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -325,10 +325,10 @@ class SQLServer_VectorStore(VectorStore):
     @classmethod
     def from_texts(
         cls: Type[SQLServer_VectorStore],
+        *,
         texts: List[str],
         embedding: Embeddings,
         metadatas: Optional[List[dict]] = None,
-        *,
         connection_string: str,
         embedding_length: int,
         table_name: str,
@@ -382,6 +382,7 @@ class SQLServer_VectorStore(VectorStore):
     @classmethod
     def from_documents(
         cls: Type[SQLServer_VectorStore],
+        *,
         documents: List[Document],
         embedding: Embeddings,
         connection_string: str,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import (
     Any,
@@ -15,7 +17,7 @@ from urllib.parse import urlparse
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
-from langchain_core.vectorstores import VST, VectorStore
+from langchain_core.vectorstores import VectorStore
 from sqlalchemy import (
     Column,
     ColumnElement,
@@ -322,14 +324,116 @@ class SQLServer_VectorStore(VectorStore):
 
     @classmethod
     def from_texts(
-        cls: Type[VST],
-        texts: List[str],
+        cls: Type[SQLServer_VectorStore],
+        connection_string: str,
         embedding: Embeddings,
+        embedding_length: int,
+        table_name: str,
+        texts: List[str],
+        db_schema: Optional[str] = None,
+        distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
         metadatas: Optional[List[dict]] = None,
+        ids: Optional[List[str]] = None,
         **kwargs: Any,
-    ) -> VST:
-        """Return VectorStore initialized from texts and embeddings."""
-        return super().from_texts(texts, embedding, metadatas, **kwargs)
+    ) -> SQLServer_VectorStore:
+        """Create a SQL Server vectorStore initialized from texts and embeddings.
+        Args:
+            connection_string: SQLServer connection string.
+                If the connection string does not contain a username & password
+                or `Trusted_Connection=yes`, Entra ID authentication is used.
+                Sample connection string format:
+                "mssql+pyodbc://username:password@servername/dbname?other_params"
+            embedding: Any embedding function implementing
+                `langchain.embeddings.base.Embeddings` interface.
+            embedding_length: The length (dimension) of the vectors to be stored in the
+                table.
+                Note that only vectors of same size can be added to the vector store.
+            table_name: The name of the table to use for storing embeddings.
+            texts: Iterable of strings to add into the vectorstore.
+            db_schema: The schema in which the vector store will be created.
+                This schema must exist and the user must have permissions to the schema.
+            distance_strategy: The distance strategy to use for comparing embeddings.
+                Default value is COSINE. Available options are:
+                - COSINE
+                - DOT
+                - EUCLIDEAN
+            metadatas: Optional list of metadatas (python dicts) associated
+                with the input texts.
+            ids: Optional list of IDs for the input texts.
+            **kwargs: vectorstore specific parameters.
+        Returns:
+            SQLServer_VectorStore: A SQL Server vectorstore.
+        """
+
+        store = cls(
+            connection_string=connection_string,
+            db_schema=db_schema,
+            distance_strategy=distance_strategy,
+            embedding_function=embedding,
+            embedding_length=embedding_length,
+            table_name=table_name,
+            **kwargs,
+        )
+
+        store.add_texts(texts, metadatas, ids, **kwargs)
+        return store
+
+    @classmethod
+    def from_documents(
+        cls: Type[SQLServer_VectorStore],
+        connection_string: str,
+        documents: List[Document],
+        embedding: Embeddings,
+        embedding_length: int,
+        table_name: str,
+        db_schema: Optional[str] = None,
+        distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
+        ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> SQLServer_VectorStore:
+        """Create a SQL Server vectorStore initialized from texts and embeddings.
+        Args:
+            connection_string: SQLServer connection string.
+                If the connection string does not contain a username & password
+                or `Trusted_Connection=yes`, Entra ID authentication is used.
+                Sample connection string format:
+                "mssql+pyodbc://username:password@servername/dbname?other_params"
+            documents: Documents to add to the vectorstore.
+            embedding: Any embedding function implementing
+                `langchain.embeddings.base.Embeddings` interface.
+            embedding_length: The length (dimension) of the vectors to be stored in the
+                table.
+                Note that only vectors of same size can be added to the vector store.
+            table_name: The name of the table to use for storing embeddings.
+            texts: Iterable of strings to add into the vectorstore.
+            db_schema: The schema in which the vector store will be created.
+                This schema must exist and the user must have permissions to the schema.
+            distance_strategy: The distance strategy to use for comparing embeddings.
+                Default value is COSINE. Available options are:
+                - COSINE
+                - DOT
+                - EUCLIDEAN
+            ids: Optional list of IDs for the input texts.
+            **kwargs: vectorstore specific parameters.
+        Returns:
+            SQLServer_VectorStore: A SQL Server vectorstore.
+        """
+
+        texts = [doc.page_content for doc in documents]
+        metadatas = [doc.metadata for doc in documents]
+
+        store = cls(
+            connection_string=connection_string,
+            db_schema=db_schema,
+            distance_strategy=distance_strategy,
+            embedding_function=embedding,
+            embedding_length=embedding_length,
+            table_name=table_name,
+            **kwargs,
+        )
+
+        store.add_texts(texts, metadatas, ids, **kwargs)
+        return store
 
     def similarity_search(
         self, query: str, k: int = 4, **kwargs: Any

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -257,7 +257,7 @@ class SQLServer_VectorStore(VectorStore):
     def _get_embedding_store(self, name: str, schema: Optional[str]) -> Any:
         DynamicBase = declarative_base(class_registry=dict())  # type: Any
         if self._embedding_length is None:
-            raise ValueError(f"Expected a value for embedding_length but got `None`.")
+            raise ValueError("Expected a value for embedding_length but got `None`.")
 
         class EmbeddingStore(DynamicBase):
             """This is the base model for SQL vector store."""
@@ -423,8 +423,16 @@ class SQLServer_VectorStore(VectorStore):
             SQLServer_VectorStore: A SQL Server vectorstore.
         """
 
-        texts = [doc.page_content for doc in documents]
-        metadatas = [doc.metadata for doc in documents]
+        texts, metadatas = [], []
+
+        for doc in documents:
+            if not isinstance(doc, Document):
+                raise ValueError(
+                    f"Expected an entry of type Document, but got {type(doc)}"
+                )
+
+            texts.append(doc.page_content)
+            metadatas.append(doc.metadata)
 
         store = cls(
             connection_string=connection_string,

--- a/libs/community/langchain_community/vectorstores/sqlserver.py
+++ b/libs/community/langchain_community/vectorstores/sqlserver.py
@@ -325,14 +325,15 @@ class SQLServer_VectorStore(VectorStore):
     @classmethod
     def from_texts(
         cls: Type[SQLServer_VectorStore],
-        connection_string: str,
+        texts: List[str],
         embedding: Embeddings,
+        metadatas: Optional[List[dict]] = None,
+        *,
+        connection_string: str,
         embedding_length: int,
         table_name: str,
-        texts: List[str],
         db_schema: Optional[str] = None,
         distance_strategy: DistanceStrategy = DEFAULT_DISTANCE_STRATEGY,
-        metadatas: Optional[List[dict]] = None,
         ids: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> SQLServer_VectorStore:
@@ -343,13 +344,15 @@ class SQLServer_VectorStore(VectorStore):
                 or `Trusted_Connection=yes`, Entra ID authentication is used.
                 Sample connection string format:
                 "mssql+pyodbc://username:password@servername/dbname?other_params"
+            texts: Iterable of strings to add into the vectorstore.
             embedding: Any embedding function implementing
                 `langchain.embeddings.base.Embeddings` interface.
+            metadatas: Optional list of metadatas (python dicts) associated
+                with the input texts.
             embedding_length: The length (dimension) of the vectors to be stored in the
                 table.
                 Note that only vectors of same size can be added to the vector store.
             table_name: The name of the table to use for storing embeddings.
-            texts: Iterable of strings to add into the vectorstore.
             db_schema: The schema in which the vector store will be created.
                 This schema must exist and the user must have permissions to the schema.
             distance_strategy: The distance strategy to use for comparing embeddings.
@@ -357,8 +360,6 @@ class SQLServer_VectorStore(VectorStore):
                 - COSINE
                 - DOT
                 - EUCLIDEAN
-            metadatas: Optional list of metadatas (python dicts) associated
-                with the input texts.
             ids: Optional list of IDs for the input texts.
             **kwargs: vectorstore specific parameters.
         Returns:
@@ -381,9 +382,9 @@ class SQLServer_VectorStore(VectorStore):
     @classmethod
     def from_documents(
         cls: Type[SQLServer_VectorStore],
-        connection_string: str,
         documents: List[Document],
         embedding: Embeddings,
+        connection_string: str,
         embedding_length: int,
         table_name: str,
         db_schema: Optional[str] = None,
@@ -393,14 +394,14 @@ class SQLServer_VectorStore(VectorStore):
     ) -> SQLServer_VectorStore:
         """Create a SQL Server vectorStore initialized from texts and embeddings.
         Args:
+            documents: Documents to add to the vectorstore.
+            embedding: Any embedding function implementing
+                `langchain.embeddings.base.Embeddings` interface.
             connection_string: SQLServer connection string.
                 If the connection string does not contain a username & password
                 or `Trusted_Connection=yes`, Entra ID authentication is used.
                 Sample connection string format:
                 "mssql+pyodbc://username:password@servername/dbname?other_params"
-            documents: Documents to add to the vectorstore.
-            embedding: Any embedding function implementing
-                `langchain.embeddings.base.Embeddings` interface.
             embedding_length: The length (dimension) of the vectors to be stored in the
                 table.
                 Note that only vectors of same size can be added to the vector store.

--- a/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_sqlserver.py
@@ -349,6 +349,52 @@ def test_that_multiple_vector_stores_can_be_created(
     new_store.drop()
 
 
+def test_sqlserver_from_texts(
+    texts: List[str],
+) -> None:
+    """Test that a call to `from_texts` initializes a
+    SQLServer vectorstore from texts."""
+    vectorstore = SQLServer_VectorStore.from_texts(
+        connection_string=_CONNECTION_STRING,
+        embedding=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        embedding_length=EMBEDDING_LENGTH,
+        table_name=_TABLE_NAME,
+        texts=texts,
+    )
+    assert vectorstore is not None
+
+    # Check that vectorstore contains the texts passed in as parameters.
+    connection = create_engine(_CONNECTION_STRING).connect()
+    result = connection.execute(text(f"select * from {_TABLE_NAME}")).fetchall()
+    connection.close()
+
+    vectorstore.drop()
+    assert len(result) == len(texts)
+
+
+def test_sqlserver_from_documents(
+    docs: List[Document],
+) -> None:
+    """Test that a call to `from_documents` initializes a
+    SQLServer vectorstore from documents."""
+    vectorstore = SQLServer_VectorStore.from_documents(
+        connection_string=_CONNECTION_STRING,
+        embedding=FakeEmbeddings(size=EMBEDDING_LENGTH),
+        embedding_length=EMBEDDING_LENGTH,
+        table_name=_TABLE_NAME,
+        documents=docs,
+    )
+    assert vectorstore is not None
+
+    # Check that vectorstore contains the texts passed in as parameters.
+    connection = create_engine(_CONNECTION_STRING).connect()
+    result = connection.execute(text(f"select * from {_TABLE_NAME}")).fetchall()
+    connection.close()
+
+    vectorstore.drop()
+    assert len(result) == len(docs)
+
+
 def test_that_schema_input_is_used() -> None:
     """Tests that when a schema is given as input to the SQLServer_VectorStore object,
     a vector store is created within the schema."""


### PR DESCRIPTION
## Why make this change?
This change adds additional functionality to `SQLServer_VectorStore` implementation. The functionalities are:
- `from_texts`
- `from_documents`
These functions can be used to create a vectorstore and immediately add embedded data into the vector store using the one function as opposed to manually creating the SQLServer_VectorStore object and calling `add_texts` or `add_documents`.
 
## What is this change?
These functions create a `SQLServer_VectorStore` that is initialized either by provided texts or provided documents.
They take in similar parameters as `SQLServer_VectorStore` with an additional parameter of `text` or `document` which is embedded and stored in the vectorstore. The vectorstore object is then returned.

## Tests
We have added 2 new tests. These tests confirm that when `from_texts` or `from_documents` is called, a vectorstore is created and data is stored as expected.
- test_sqlserver_from_texts
- test_sqlserver_from_documents

![image](https://github.com/user-attachments/assets/e42d0b54-eac9-4d76-8ac6-acde88e3ecc0)
